### PR TITLE
Add frontend CI (svelte-check + eslint)

### DIFF
--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -1,0 +1,49 @@
+name: Frontend Type Check
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'static/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - 'svelte.config.js'
+      - 'vite.config.ts'
+      - 'eslint.config.js'
+      - '.github/workflows/test-frontend.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'static/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - 'svelte.config.js'
+      - 'vite.config.ts'
+      - 'eslint.config.js'
+      - '.github/workflows/test-frontend.yml'
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run svelte-check
+        run: npm run check
+
+      - name: Run eslint
+        run: npm run lint

--- a/src/lib/components/ColumnView.svelte
+++ b/src/lib/components/ColumnView.svelte
@@ -139,7 +139,7 @@
   onscroll={handleScroll}
 >
   <div class="column-scroll-area" style="width: {totalWidth}px; height: {rowsPerCol * ROW_HEIGHT}px; position: relative;">
-    {#each { length: visibleEndCol - visibleStartCol } as _, ci}
+    {#each { length: visibleEndCol - visibleStartCol } as _, ci (visibleStartCol + ci)}
       {@const colIdx = visibleStartCol + ci}
       {@const colEntries = getColumnEntries(colIdx)}
       <div

--- a/src/lib/components/DiskUsagePane.svelte
+++ b/src/lib/components/DiskUsagePane.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy, tick } from 'svelte';
+  import { SvelteMap } from 'svelte/reactivity';
   import { analyzeDiskUsage, cancelDiskUsage } from '$lib/services/tauri';
   import { formatSize } from '$lib/utils/format';
   import type { DiskUsageEntry, DiskUsageEvent, DiskUsageLevelData } from '$lib/types';
@@ -41,7 +42,7 @@
   let activeTab = $state<'overview' | 'details'>('overview');
 
   // Cache of completed scans keyed by path
-  const cache = new Map<string, CachedScan>();
+  const cache = new SvelteMap<string, CachedScan>();
 
   // Drill-down navigation
   let currentPath = $state('');
@@ -385,7 +386,7 @@
   <!-- Breadcrumb trail -->
   {#if pathHistory.length > 0}
     <div class="breadcrumb-trail">
-      {#each pathHistory as crumb, i}
+      {#each pathHistory as crumb, i (crumb.path)}
         <button class="breadcrumb-item" onclick={() => navigateTo(i)}>
           {crumb.title}
         </button>
@@ -439,7 +440,7 @@
 
         <!-- Legend -->
         <div class="du-legend">
-          {#each sortedEntries.slice(0, 10) as entry, i}
+          {#each sortedEntries.slice(0, 10) as entry, i (entry.path)}
             <button
               class="legend-item"
               class:clickable={entry.is_dir}
@@ -482,7 +483,7 @@
             </tr>
           </thead>
           <tbody>
-            {#each sortedEntries as entry}
+            {#each sortedEntries as entry (entry.path)}
               {@const pct = totalSize > 0 ? (entry.size / totalSize) * 100 : 0}
               <tr
                 class:is-dir={entry.is_dir}

--- a/src/lib/components/FilePanel.svelte
+++ b/src/lib/components/FilePanel.svelte
@@ -193,8 +193,8 @@
     const statusMap = side === 'right' ? comparisonState.rightStatuses : comparisonState.leftStatuses;
 
     // Pre-build sets of top-level directories that have modified/changed children
-    const dirModified = new Set<string>();
-    const dirChanged = new Set<string>();
+    const dirModified = new SvelteSet<string>();
+    const dirChanged = new SvelteSet<string>();
     for (const [key, val] of statusMap) {
       if (val === 'same') continue;
       const slashIdx = key.indexOf('/');

--- a/src/lib/components/LocalBatchEditDialog.svelte
+++ b/src/lib/components/LocalBatchEditDialog.svelte
@@ -138,7 +138,6 @@
   const progressPct = $derived(filesTotal > 0 ? Math.round((filesDone / filesTotal) * 100) : 0);
 </script>
 
-<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 <div
   class="dialog-overlay"
   role="dialog"
@@ -250,7 +249,7 @@
           </button>
           {#if showFailedList}
             <ul class="failed-list">
-              {#each failedPaths as fp}
+              {#each failedPaths as fp (fp)}
                 <li>{fp}</li>
               {/each}
             </ul>

--- a/src/lib/components/PreviewPane.svelte
+++ b/src/lib/components/PreviewPane.svelte
@@ -204,7 +204,7 @@
       <div class="preview-loading">Loading model info...</div>
     {:else if modelError}
       <div class="preview-file-info">
-        <div class="preview-file-icon">{'\uD83E\uDDE0'}</div>
+        <div class="preview-file-icon">\uD83E\uDDE0</div>
         <div class="preview-file-name">{entry.name}</div>
         <div class="preview-file-meta"><div>{modelError}</div></div>
       </div>
@@ -290,7 +290,7 @@
       <!-- Single model view -->
       <div class="preview-file-info">
         <div class="preview-model-header">
-          <span class="preview-model-icon">{'\uD83E\uDDE0'}</span>
+          <span class="preview-model-icon">\uD83E\uDDE0</span>
           <div class="preview-model-title">
             <div class="preview-model-name">{modelMetadata.model_name ?? entry.name}</div>
             <span class="preview-model-badge">{modelMetadata.format}</span>

--- a/src/lib/components/SyncDialog.svelte
+++ b/src/lib/components/SyncDialog.svelte
@@ -31,7 +31,7 @@
   let scanning = $state(false);
   let scanComplete = $state(false);
   let filter = $state<'all' | 'new' | 'modified' | 'deleted'>('all');
-  let selectedPaths = $state(new SvelteSet<string>());
+  let selectedPaths = new SvelteSet<string>();
   let cursorIndex = $state(0);
   let currentSyncId = $state('');
   let listEl: HTMLDivElement | undefined = $state(undefined);
@@ -78,7 +78,7 @@
 
     currentSyncId = id;
     allEntries = [];
-    selectedPaths = new SvelteSet<string>();
+    selectedPaths.clear();
     cursorIndex = 0;
     scanning = true;
     scanComplete = false;
@@ -99,7 +99,7 @@
         allEntries = [...allEntries, event as SyncEntry];
         // Auto-select new and modified entries
         if (event.status === 'new' || event.status === 'modified') {
-          selectedPaths = new SvelteSet([...selectedPaths, event.relative_path]);
+          selectedPaths.add(event.relative_path);
         }
       } else if (event.type === 'Done') {
         newCount = event.new_count;
@@ -130,23 +130,21 @@
   }
 
   function toggleSelection(path: string) {
-    const next = new SvelteSet(selectedPaths);
-    if (next.has(path)) {
-      next.delete(path);
+    if (selectedPaths.has(path)) {
+      selectedPaths.delete(path);
     } else {
-      next.add(path);
+      selectedPaths.add(path);
     }
-    selectedPaths = next;
   }
 
   function selectAll() {
-    selectedPaths = new SvelteSet(filtered.map((e) => e.relative_path));
+    selectedPaths.clear();
+    for (const e of filtered) selectedPaths.add(e.relative_path);
   }
 
   function selectNone() {
     // Only deselect entries visible in the current filter
-    const visiblePaths = new SvelteSet(filtered.map((e) => e.relative_path));
-    selectedPaths = new SvelteSet([...selectedPaths].filter((p) => !visiblePaths.has(p)));
+    for (const e of filtered) selectedPaths.delete(e.relative_path);
   }
 
   function handleSync() {

--- a/src/lib/state/panels.svelte.ts
+++ b/src/lib/state/panels.svelte.ts
@@ -1,5 +1,5 @@
 import type { FileEntry, SortField, SortDirection, ViewMode, PanelBackend, S3ConnectionInfo, SftpConnectionInfo, ArchiveInfo, GitRepoInfo, DirListEvent } from '$lib/types';
-import { SvelteSet } from 'svelte/reactivity';
+import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 import { sortEntries } from '$lib/utils/sort';
 import { listDirectory, listDirectoryStreamed, listArchive, watchDirectory, unwatchDirectory, getGitRepoInfo, getDirectorySize } from '$lib/services/tauri';
 import { s3Connect, s3Disconnect, s3ListObjects, s3IsObjectEncrypted } from '$lib/services/s3';
@@ -85,7 +85,7 @@ export class PanelData {
 
   // Path→entry index for O(1) lookups (rebuilt when entries change)
   private entryByPath = $derived.by(() => {
-    const map = new Map<string, FileEntry>();
+    const map = new SvelteMap<string, FileEntry>();
     for (const e of this.entries) map.set(e.path, e);
     return map;
   });


### PR DESCRIPTION
## Summary

Closes the JS/TS CI coverage gap: existing workflows all gate on `paths: ['src-tauri/**']`, so the recent typescript v6, typescript-eslint, and @types/node bumps merged with **zero** automated validation. This adds a `test-frontend.yml` that runs `svelte-check` and `eslint` on push/PR when frontend files change.

## Two commits

1. **Fix existing svelte eslint errors** — 14 errors on main cleaned up first so enforcement starts from a clean baseline:
    - `{#each}` blocks given keys (ColumnView, DiskUsagePane, LocalBatchEditDialog)
    - Plain `Map`/`Set` replaced with `SvelteMap`/`SvelteSet` in reactive contexts (DiskUsagePane, FilePanel, panels.svelte.ts)
    - Unused `svelte-ignore` comment dropped (LocalBatchEditDialog)
    - Brain emoji inlined instead of mustache-wrapping a string literal (PreviewPane)
    - `SyncDialog.selectedPaths` refactored: mutate the `SvelteSet` instead of reassigning, so the `$state()` wrap can be dropped

2. **Add the workflow** — `svelte-check` + `eslint`, both enforced.

## Test plan

- [x] `npm run check` clean (487 files, 0 errors, 0 warnings)
- [x] `npm run lint` clean (0 errors; 45 warnings remain — separate cleanup, not blocked)
- [ ] This PR's own CI run should pass once the workflow lands