### PR TITLE
Surface remote-connection failures instead of swallowing them

### DIFF
--- a/src-tauri/src/commands/sftp.rs
+++ b/src-tauri/src/commands/sftp.rs
@@ -76,11 +76,11 @@ pub async fn sftp_connect(
             // trigger a system permission dialog.  The original TCP attempt
             // often fails before the user can approve it, so retry once
             // after a short pause.
-            log::info!(
-                "SFTP connect to {host}:{port} failed ({first_err}), retrying once…"
+            log::warn!(
+                "SFTP connect to {host}:{port} failed ({first_err}), retrying once after 3s…"
             );
             tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-            sftp::client::build_sftp_client(
+            match sftp::client::build_sftp_client(
                 &host,
                 port,
                 &username,
@@ -93,9 +93,25 @@ pub async fn sftp_connect(
                 keepalive_interval,
                 operation_timeout,
             )
-            .await?
+            .await
+            {
+                Ok(c) => c,
+                Err(retry_err) => {
+                    log::error!(
+                        "SFTP connect to {host}:{port} failed after retry: {retry_err}"
+                    );
+                    return Err(sftperr(format!(
+                        "SFTP connect to {host}:{port} failed after 2 attempts: {retry_err}"
+                    )));
+                }
+            }
         }
-        Err(e) => return Err(e),
+        Err(e) => {
+            log::error!("SFTP connect to {host}:{port} failed: {e}");
+            return Err(sftperr(format!(
+                "SFTP connect to {host}:{port} failed: {e}"
+            )));
+        }
     };
 
     let home_dir = conn.home_dir.clone();

--- a/src-tauri/src/s3/helpers.rs
+++ b/src-tauri/src/s3/helpers.rs
@@ -299,13 +299,19 @@ pub async fn upload_file_multipart(
 
     // 5. On any failure → abort multipart upload (best-effort) → return error
     if let Some(err) = first_error {
-        let _ = client
+        if let Err(abort_err) = client
             .abort_multipart_upload()
             .bucket(bucket)
             .key(key)
             .upload_id(&upload_id)
             .send()
-            .await;
+            .await
+        {
+            log::warn!(
+                "Failed to abort multipart upload for {bucket}/{key} (upload_id={upload_id}); \
+                 part may be orphaned and continue to incur storage cost: {abort_err}"
+            );
+        }
         return Err(err);
     }
 
@@ -402,13 +408,19 @@ pub async fn copy_object_multipart(
             }
             Err(e) => {
                 // Abort on failure (best-effort)
-                let _ = dest_client
+                if let Err(abort_err) = dest_client
                     .abort_multipart_upload()
                     .bucket(dest_bucket)
                     .key(dest_key)
                     .upload_id(&upload_id)
                     .send()
-                    .await;
+                    .await
+                {
+                    log::warn!(
+                        "Failed to abort multipart copy to {dest_bucket}/{dest_key} \
+                         (upload_id={upload_id}); part may be orphaned: {abort_err}"
+                    );
+                }
                 return Err(s3err(e.to_string()));
             }
         }

--- a/src-tauri/src/sftp/service.rs
+++ b/src-tauri/src/sftp/service.rs
@@ -105,7 +105,13 @@ impl SftpService {
         // Try to get filesystem info for free_space
         let free_space = match self.session.fs_info(path).await {
             Ok(Some(info)) => info.blocks_avail * info.fragment_size,
-            _ => 0,
+            Ok(None) => 0,
+            Err(e) => {
+                log::warn!(
+                    "SFTP fs_info on '{path}' failed ({e}); reporting free_space as 0"
+                );
+                0
+            }
         };
 
         Ok(DirListing {
@@ -507,8 +513,14 @@ impl SftpService {
 
     /// Ensure a remote directory and all parents exist.
     async fn ensure_remote_dir(&self, path: &str) -> Result<(), FmError> {
-        if self.session.try_exists(path).await.unwrap_or(false) {
-            return Ok(());
+        match self.session.try_exists(path).await {
+            Ok(true) => return Ok(()),
+            Ok(false) => {}
+            Err(e) => {
+                log::warn!(
+                    "SFTP try_exists on '{path}' failed ({e}); attempting create anyway"
+                );
+            }
         }
         // Recurse to parent
         if let Some((parent, _)) = path.rsplit_once('/') {
@@ -516,8 +528,14 @@ impl SftpService {
                 Box::pin(self.ensure_remote_dir(parent)).await?;
             }
         }
-        // Create this level (ignore error if it already exists)
-        let _ = self.session.create_dir(path).await;
+        // Create this level. If it already exists (race / try_exists failed
+        // but the dir does exist), the server returns an error we can ignore;
+        // a real failure (permission denied, quota, etc.) will surface when
+        // the subsequent file write fails on this path, but log it here for
+        // diagnosis.
+        if let Err(e) = self.session.create_dir(path).await {
+            log::warn!("SFTP create_dir '{path}' failed: {e}");
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Why

User report: SFTP connect to a host that's not reachable produced only INFO-level log lines like

\`\`\`
[INFO] SFTP connect to 10.10.10.27:22 failed (SFTP: SSH connect failed: Operation timed out (os error 60)), retrying once…
\`\`\`

and the user had no idea anything was happening — they ended up clicking Connect 4 times. The intermediate "retrying" step is invisible at default log levels, and several other remote-ops error paths were similarly silent.

This PR addresses the highest-impact silent-failure spots identified in a wider audit. Architectural follow-ups (batch error aggregation, connection-error classification) are deferred to Phase 2.

## What changed

**`commands/sftp.rs` — connect feedback**
- Intermediate retry log: \`INFO\` → \`WARN\` with clearer wording ("retrying once after 3s…")
- Final connect failure now logs at \`ERROR\` and the \`FmError\` returned to the UI is wrapped with \`SFTP connect to {host}:{port} failed [after 2 attempts]: …\` so the connect dialog shows useful context instead of just \`Operation timed out (os error 60)\`.

**`sftp/service.rs` — directory ops**
- \`fs_info\` failure no longer silently returns \`free_space: 0\`; logs a warning with the path and error.
- \`ensure_remote_dir\` no longer swallows \`try_exists\` / \`create_dir\` errors. Behavior unchanged on success (the function still returns \`Ok\` if the path is reachable for the subsequent write), but failures show up in logs so a permission or quota issue is diagnosable.

**\`s3/helpers.rs\` — multipart cleanup**
- Both \`upload_file_multipart\` and the multipart-copy path now log a WARN if \`abort_multipart_upload\` itself fails, so orphaned-multipart situations (incomplete uploads that continue to incur S3 storage cost) are visible.

## Out of scope (Phase 2 candidates)

- Skip-list / soft-failure summary for recursive transfers (e.g. \`download_directory\` silently skips unreadable subdirs at \`sftp/service.rs:370\`)
- Connection-error classification (\`TimedOut\` / \`Refused\` / \`AuthFailed\` / \`HostUnreachable\`) with friendly messages
- Download resume on checksum mismatch

## Test plan

- [x] \`cargo check\` clean (only the pre-existing md5 deprecation warnings already fixed in #33)
- [x] \`cargo check --tests\` clean
- [ ] Manual: SFTP connect to an unreachable host — verify dialog shows \`SFTP connect to <host>:<port> failed after 2 attempts: …\` instead of bare \`Operation timed out\`