### PR TITLE
Add in-app SMB/NFS network share mounting

### DIFF
--- a/src-tauri/src/commands/volumes.rs
+++ b/src-tauri/src/commands/volumes.rs
@@ -10,6 +10,57 @@ pub fn list_volumes() -> Result<Vec<VolumeInfo>, FmError> {
     list_volumes_impl()
 }
 
+/// Mount an SMB or NFS network share via the operating system and return the
+/// local mount point so the caller can navigate to it as a normal folder.
+///
+/// This deliberately delegates to the OS rather than speaking SMB/NFS natively:
+///   - macOS: `open <url>` hands the URL to NetFS, which mounts under `/Volumes`
+///     and reuses the system Keychain. The new mount appears in `list_volumes`
+///     and is ejectable, so the rest of the app needs no changes.
+///   - Linux: `gio mount` (GVfs) mounts the share unprivileged under the user's
+///     gvfs runtime directory. NFS is not supported there (it needs root).
+///
+/// `protocol` is "smb" or "nfs". `password`/`username`/`domain` are optional;
+/// when omitted the OS may prompt (macOS) or fall back to guest access.
+#[tauri::command]
+pub async fn mount_network_share(
+    protocol: String,
+    host: String,
+    share: String,
+    username: Option<String>,
+    password: Option<String>,
+    domain: Option<String>,
+) -> Result<String, FmError> {
+    tauri::async_runtime::spawn_blocking(move || {
+        mount_network_share_impl(
+            &protocol,
+            &host,
+            &share,
+            username.as_deref(),
+            password.as_deref(),
+            domain.as_deref(),
+        )
+    })
+    .await
+    .map_err(|e| FmError::Other(format!("Mount task failed: {e}")))?
+}
+
+/// Percent-encode a userinfo component (username/password) for use in a URL.
+/// Encodes everything outside the RFC 3986 "unreserved" set so credentials
+/// containing `@`, `:`, `/`, spaces, etc. survive being placed in the URL.
+fn encode_userinfo(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(b as char);
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
 /// Eject (macOS) or unmount (Linux) the volume at the given mount point.
 /// Only call for volumes the backend marked as `ejectable`.
 #[tauri::command]
@@ -259,6 +310,193 @@ fn eject_volume_impl(mount_point: &str) -> Result<(), FmError> {
         };
         Err(FmError::Other(format!("Eject failed: {msg}")))
     }
+}
+
+// ── Network share mounting ───────────────────────────────────────────────────
+
+/// macOS: build an `smb://` / `nfs://` URL and let NetFS mount it via `open`.
+/// We can't know the exact `/Volumes/<name>` NetFS will choose (it disambiguates
+/// duplicates with a numeric suffix), so we snapshot `/Volumes` before and after
+/// and return whatever new entry appears.
+#[cfg(target_os = "macos")]
+fn mount_network_share_impl(
+    protocol: &str,
+    host: &str,
+    share: &str,
+    username: Option<&str>,
+    password: Option<&str>,
+    _domain: Option<&str>,
+) -> Result<String, FmError> {
+    let scheme = match protocol {
+        "smb" => "smb",
+        "nfs" => "nfs",
+        other => return Err(FmError::Other(format!("Unsupported protocol: {other}"))),
+    };
+
+    // NFS has no in-URL auth; SMB carries optional credentials in the userinfo.
+    let userinfo = if scheme == "smb" {
+        match (username, password) {
+            (Some(u), Some(p)) => format!("{}:{}@", encode_userinfo(u), encode_userinfo(p)),
+            (Some(u), None) => format!("{}@", encode_userinfo(u)),
+            _ => String::new(),
+        }
+    } else {
+        String::new()
+    };
+    let share = share.trim_start_matches('/');
+    let url = format!("{scheme}://{userinfo}{host}/{share}");
+
+    let before = volume_names();
+
+    // `-g` keeps Finder from being brought to the foreground.
+    let out = Command::new("open")
+        .arg("-g")
+        .arg(&url)
+        .output()
+        .map_err(|e| FmError::Other(format!("Failed to run open: {e}")))?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        return Err(FmError::Other(format!(
+            "Failed to start mount: {}",
+            stderr.trim()
+        )));
+    }
+
+    // Poll for the newly mounted volume (up to ~20s). If the share needs
+    // credentials we didn't supply, NetFS shows its own auth dialog and this
+    // will time out — the message points the user there.
+    for _ in 0..40 {
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        let now = volume_names();
+        if let Some(new_mount) = now.difference(&before).next() {
+            return Ok(new_mount.clone());
+        }
+    }
+    Err(FmError::Other(
+        "Timed out waiting for the share to mount. It may require authentication — check Finder."
+            .to_string(),
+    ))
+}
+
+/// macOS: snapshot the set of mount points currently under `/Volumes`.
+#[cfg(target_os = "macos")]
+fn volume_names() -> std::collections::HashSet<String> {
+    let mut set = std::collections::HashSet::new();
+    if let Ok(rd) = fs::read_dir("/Volumes") {
+        for entry in rd.flatten() {
+            set.insert(entry.path().to_string_lossy().into_owned());
+        }
+    }
+    set
+}
+
+/// Linux: mount SMB shares unprivileged through GVfs (`gio mount`). The username
+/// and domain are placed in the URL so only the password needs to be fed on
+/// stdin, then we locate the resulting entry under the gvfs runtime directory.
+/// NFS isn't supported here (it requires a privileged `mount -t nfs`).
+#[cfg(target_os = "linux")]
+fn mount_network_share_impl(
+    protocol: &str,
+    host: &str,
+    share: &str,
+    username: Option<&str>,
+    password: Option<&str>,
+    domain: Option<&str>,
+) -> Result<String, FmError> {
+    use std::io::Write;
+    use std::process::Stdio;
+
+    match protocol {
+        "smb" => {}
+        "nfs" => {
+            return Err(FmError::Other(
+                "NFS mounting on Linux requires root. Mount it manually \
+                 (e.g. `sudo mount -t nfs host:/share /mnt/...`), then browse it as a local folder."
+                    .to_string(),
+            ));
+        }
+        other => return Err(FmError::Other(format!("Unsupported protocol: {other}"))),
+    }
+
+    if Command::new("gio").arg("--help").output().is_err() {
+        return Err(FmError::Other(
+            "`gio` is not available. Install it (glib2/gvfs) or mount the share manually."
+                .to_string(),
+        ));
+    }
+
+    let share = share.trim_start_matches('/');
+    // gvfs URI: smb://[domain;][user@]host/share
+    let mut userpart = String::new();
+    if let Some(d) = domain.filter(|d| !d.is_empty()) {
+        userpart.push_str(&format!("{d};"));
+    }
+    if let Some(u) = username.filter(|u| !u.is_empty()) {
+        userpart.push_str(&format!("{u}@"));
+    }
+    let url = format!("smb://{userpart}{host}/{share}");
+
+    let mut child = Command::new("gio")
+        .arg("mount")
+        .arg(&url)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| FmError::Other(format!("Failed to run gio: {e}")))?;
+
+    // `gio mount` prompts for the password on stdin (user/domain are in the URL).
+    // Feed the password (or a blank line to accept guest/anonymous access).
+    if let Some(stdin) = child.stdin.as_mut() {
+        let _ = writeln!(stdin, "{}", password.unwrap_or(""));
+    }
+    let out = child
+        .wait_with_output()
+        .map_err(|e| FmError::Other(format!("gio mount failed: {e}")))?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        return Err(FmError::Other(format!(
+            "Failed to mount share: {}",
+            stderr.trim()
+        )));
+    }
+
+    // Locate the gvfs entry, e.g.
+    //   /run/user/<uid>/gvfs/smb-share:server=host,share=share[,user=...]
+    let uid = nix::unistd::getuid().as_raw();
+    let gvfs = format!("/run/user/{uid}/gvfs");
+    let host_l = host.to_lowercase();
+    let needle_server = format!("server={host_l}");
+    let needle_share = format!("share={}", share.to_lowercase());
+    if let Ok(rd) = fs::read_dir(&gvfs) {
+        for entry in rd.flatten() {
+            let name = entry.file_name().to_string_lossy().to_lowercase();
+            if name.starts_with("smb-share:")
+                && name.contains(&needle_server)
+                && name.contains(&needle_share)
+            {
+                return Ok(entry.path().to_string_lossy().into_owned());
+            }
+        }
+    }
+    Err(FmError::Other(format!(
+        "Share mounted but its location under {gvfs} could not be found."
+    )))
+}
+
+/// Fallback for platforms without an in-app mount path (e.g. Windows for now).
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn mount_network_share_impl(
+    _protocol: &str,
+    _host: &str,
+    _share: &str,
+    _username: Option<&str>,
+    _password: Option<&str>,
+    _domain: Option<&str>,
+) -> Result<String, FmError> {
+    Err(FmError::Other(
+        "Mounting network shares from the app is not supported on this platform yet.".to_string(),
+    ))
 }
 
 #[cfg(target_os = "linux")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -261,6 +261,7 @@ pub fn run() {
             // volume commands
             commands::volumes::list_volumes,
             commands::volumes::eject_volume,
+            commands::volumes::mount_network_share,
             // watcher commands
             commands::watcher::watch_directory,
             commands::watcher::unwatch_directory,

--- a/src/lib/components/ConnectionManager.svelte
+++ b/src/lib/components/ConnectionManager.svelte
@@ -5,6 +5,7 @@
   import { connectionsState } from '$lib/state/connections.svelte';
   import S3ConnectDialog from '$lib/components/S3ConnectDialog.svelte';
   import SftpConnectDialog from '$lib/components/SftpConnectDialog.svelte';
+  import NetworkShareDialog from '$lib/components/NetworkShareDialog.svelte';
   import { resolveCapabilities, getProviderIcon } from '$lib/data/s3-providers';
   import { error } from '$lib/services/log';
   import { oidcRefresh } from '$lib/services/s3';
@@ -21,7 +22,7 @@
 
   type Selection =
     | { mode: 'saved' }
-    | { mode: 'new'; protocol: 's3' | 'sftp' }
+    | { mode: 'new'; protocol: 's3' | 'sftp' | 'network' }
     | { mode: 'edit'; profile: S3Profile }
     | { mode: 'edit-sftp'; profile: SftpProfile };
 
@@ -104,6 +105,25 @@
     const info: SftpConnectionInfo = { connectionId, host, port, username, agentSocket };
     try {
       await panel.connectSftp(info, password, keyPath, keyPassphrase, agentSocket);
+      onClose();
+    } catch (err: unknown) {
+      connectError = err instanceof Error ? err.message : String(err);
+      error(String(err));
+    }
+  }
+
+  async function handleMountShare(
+    protocol: 'smb' | 'nfs',
+    host: string,
+    share: string,
+    username?: string,
+    password?: string,
+    domain?: string,
+  ) {
+    connectError = '';
+    const panel = panels.active;
+    try {
+      await panel.mountShare(protocol, host, share, username, password, domain);
       onClose();
     } catch (err: unknown) {
       connectError = err instanceof Error ? err.message : String(err);
@@ -338,6 +358,14 @@
           SFTP
           <span class="sidebar-hint">SSH File Transfer</span>
         </button>
+        <button
+          class="sidebar-item"
+          class:active={selected.mode === 'new' && selected.protocol === 'network'}
+          onclick={() => { selected = { mode: 'new', protocol: 'network' }; dialogKey++; }}
+        >
+          Network Share
+          <span class="sidebar-hint">SMB & NFS (mount)</span>
+        </button>
       </div>
 
       <div class="manager-main">
@@ -421,6 +449,14 @@
               onConnect={handleConnectSftp}
               onCancel={onClose}
               onSave={handleSaveSftp}
+            />
+          {/key}
+        {:else if selected.mode === 'new' && selected.protocol === 'network'}
+          {#key dialogKey}
+            <NetworkShareDialog
+              embedded={true}
+              onConnect={handleMountShare}
+              onCancel={onClose}
             />
           {/key}
         {:else}

--- a/src/lib/components/NetworkShareDialog.svelte
+++ b/src/lib/components/NetworkShareDialog.svelte
@@ -1,0 +1,272 @@
+<script lang="ts">
+  interface Props {
+    onConnect: (protocol: 'smb' | 'nfs', host: string, share: string, username?: string, password?: string, domain?: string) => void;
+    onCancel: () => void;
+    embedded?: boolean;
+  }
+
+  let { onConnect, onCancel, embedded = false }: Props = $props();
+
+  let protocol = $state<'smb' | 'nfs'>('smb');
+  let host = $state('');
+  let share = $state('');
+  let username = $state('');
+  let password = $state('');
+  let domain = $state('');
+  let connecting = $state(false);
+  let connectError = $state('');
+
+  function canConnect(): boolean {
+    return !!host && !!share;
+  }
+
+  async function handleConnect() {
+    if (!canConnect()) return;
+    connecting = true;
+    connectError = '';
+    try {
+      onConnect(
+        protocol,
+        host.trim(),
+        share.trim(),
+        protocol === 'smb' && username ? username : undefined,
+        protocol === 'smb' && password ? password : undefined,
+        protocol === 'smb' && domain ? domain : undefined,
+      );
+    } catch (err: unknown) {
+      connectError = err instanceof Error ? err.message : String(err);
+    } finally {
+      connecting = false;
+    }
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter' && canConnect()) {
+      e.preventDefault();
+      handleConnect();
+    }
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+<div class="share-dialog" class:embedded onkeydown={handleKeydown} role="form">
+  <div class="main-body">
+    <div class="conn-tab-bar">
+      <button class="conn-tab-btn active">Network Share</button>
+    </div>
+
+    {#if connectError}
+      <div class="error-msg">{connectError}</div>
+    {/if}
+
+    <div class="field">
+      <!-- svelte-ignore a11y_label_has_associated_control -->
+      <label>Protocol</label>
+      <div class="auth-options">
+        <label class="radio-label">
+          <input type="radio" bind:group={protocol} value="smb" />
+          SMB / CIFS
+        </label>
+        <label class="radio-label">
+          <input type="radio" bind:group={protocol} value="nfs" />
+          NFS
+        </label>
+      </div>
+    </div>
+
+    <div class="field">
+      <label for="share-host">Server</label>
+      <input id="share-host" type="text" bind:value={host} placeholder="nas.local or 192.168.1.10" />
+    </div>
+
+    <div class="field">
+      <label for="share-path">{protocol === 'nfs' ? 'Export Path' : 'Share Name'}</label>
+      <input id="share-path" type="text" bind:value={share} placeholder={protocol === 'nfs' ? '/exports/data' : 'media'} />
+    </div>
+
+    {#if protocol === 'smb'}
+      <div class="field-row">
+        <div class="field" style="flex:2">
+          <label for="share-username">Username <span class="optional">(optional)</span></label>
+          <input id="share-username" type="text" bind:value={username} placeholder="guest if empty" />
+        </div>
+        <div class="field" style="flex:1">
+          <label for="share-domain">Domain <span class="optional">(optional)</span></label>
+          <input id="share-domain" type="text" bind:value={domain} placeholder="WORKGROUP" />
+        </div>
+      </div>
+      <div class="field">
+        <label for="share-password">Password <span class="optional">(optional)</span></label>
+        <input id="share-password" type="password" bind:value={password} placeholder="Enter password" />
+      </div>
+    {:else}
+      <div class="hint-msg">
+        NFS mounts have no credentials. On Linux, NFS requires mounting manually with root —
+        this works on macOS only.
+      </div>
+    {/if}
+  </div>
+
+  <div class="main-footer">
+    <button class="dialog-btn primary" onclick={handleConnect} disabled={!canConnect() || connecting}>
+      {connecting ? 'Mounting...' : 'Mount'}
+    </button>
+    <button class="dialog-btn" onclick={onCancel}>Cancel</button>
+  </div>
+</div>
+
+<style>
+  .share-dialog {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    overflow: hidden;
+  }
+
+  .main-body {
+    padding: 20px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    flex: 1;
+    overflow-y: auto;
+  }
+
+  .conn-tab-bar {
+    display: flex;
+    gap: 0;
+    border-bottom: 1px solid var(--border-subtle);
+    margin-bottom: 8px;
+    flex-shrink: 0;
+  }
+
+  .conn-tab-btn {
+    padding: 6px 16px;
+    font-size: 12px;
+    font-family: inherit;
+    font-weight: 500;
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    color: var(--text-secondary);
+    cursor: default;
+    transition: color var(--transition-fast), border-color var(--transition-fast);
+  }
+
+  .conn-tab-btn.active {
+    border-bottom: 2px solid var(--text-accent);
+    color: var(--text-accent);
+  }
+
+  .main-footer {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    padding: 16px 24px;
+    border-top: 1px solid var(--dialog-border);
+    flex-shrink: 0;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .field label {
+    font-size: 12px;
+    color: var(--text-secondary);
+  }
+
+  .field-row {
+    display: flex;
+    gap: 12px;
+  }
+
+  .field input[type="text"],
+  .field input[type="password"] {
+    padding: 7px 10px;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    background: var(--bg-input);
+    color: var(--text-primary);
+    font-size: 13px;
+    font-family: inherit;
+  }
+
+  .field input:focus {
+    outline: none;
+    border-color: var(--border-active);
+  }
+
+  .auth-options {
+    display: flex;
+    gap: 16px;
+    padding: 4px 0;
+  }
+
+  .radio-label {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 13px;
+    color: var(--text-primary);
+    cursor: pointer;
+  }
+
+  .optional {
+    font-weight: 400;
+    opacity: 0.6;
+  }
+
+  .error-msg {
+    font-size: 12px;
+    color: var(--warning-color);
+    padding: 8px 12px;
+    background: rgba(255, 100, 100, 0.1);
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(255, 100, 100, 0.2);
+  }
+
+  .hint-msg {
+    font-size: 12px;
+    color: var(--text-secondary);
+    padding: 8px 12px;
+    background: var(--bg-hover);
+    border-radius: var(--radius-sm);
+    line-height: 1.4;
+  }
+
+  .dialog-btn {
+    padding: 8px 24px;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    background: var(--bg-surface);
+    color: var(--text-primary);
+    cursor: pointer;
+    font-size: 13px;
+    font-family: inherit;
+    transition: background var(--transition-fast), border-color var(--transition-fast);
+  }
+
+  .dialog-btn:hover:not(:disabled) {
+    background: var(--bg-hover);
+    border-color: var(--text-accent);
+  }
+
+  .dialog-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .dialog-btn.primary {
+    background: rgba(110,168,254,0.2);
+    border-color: var(--border-active);
+    color: var(--text-accent);
+  }
+
+  .dialog-btn.primary:hover:not(:disabled) {
+    background: rgba(110,168,254,0.3);
+  }
+</style>

--- a/src/lib/services/mount.ts
+++ b/src/lib/services/mount.ts
@@ -1,0 +1,26 @@
+import { invoke } from '@tauri-apps/api/core';
+
+/**
+ * Mount an SMB or NFS network share via the operating system and return the
+ * local mount point. The share is then browsed as a normal local folder.
+ *
+ * macOS hands the URL to NetFS (mounts under /Volumes, reuses the Keychain);
+ * Linux uses GVfs (`gio mount`). NFS is macOS-only here — Linux NFS needs root.
+ */
+export async function mountNetworkShare(
+  protocol: 'smb' | 'nfs',
+  host: string,
+  share: string,
+  username?: string,
+  password?: string,
+  domain?: string,
+): Promise<string> {
+  return await invoke<string>('mount_network_share', {
+    protocol,
+    host,
+    share,
+    username: username ?? null,
+    password: password ?? null,
+    domain: domain ?? null,
+  });
+}

--- a/src/lib/state/panels.svelte.ts
+++ b/src/lib/state/panels.svelte.ts
@@ -4,6 +4,7 @@ import { sortEntries } from '$lib/utils/sort';
 import { listDirectory, listDirectoryStreamed, listArchive, watchDirectory, unwatchDirectory, getGitRepoInfo, getDirectorySize } from '$lib/services/tauri';
 import { s3Connect, s3Disconnect, s3ListObjects, s3IsObjectEncrypted } from '$lib/services/s3';
 import { sftpConnect, sftpDisconnect, sftpListObjects } from '$lib/services/sftp';
+import { mountNetworkShare } from '$lib/services/mount';
 import { appState } from '$lib/state/app.svelte';
 import { error as logError } from '$lib/services/log';
 
@@ -459,6 +460,22 @@ export class PanelData {
     } catch (err: unknown) {
       this.error = err instanceof Error ? err.message : String(err);
       this.loading = false;
+    }
+  }
+
+  /// Mount an SMB/NFS share through the OS and navigate this panel to it as a
+  /// local folder. Throws on failure so the caller can surface the error.
+  async mountShare(protocol: 'smb' | 'nfs', host: string, share: string, username?: string, password?: string, domain?: string) {
+    this.loading = true;
+    this.error = null;
+    try {
+      const mountPoint = await mountNetworkShare(protocol, host, share, username, password, domain);
+      this.clearHistory();
+      this.backend = 'local';
+      await this.loadDirectory(mountPoint);
+    } catch (err: unknown) {
+      this.loading = false;
+      throw err;
     }
   }
 


### PR DESCRIPTION
## What

Adds a **Network Share** connection option that mounts SMB/NFS shares via the operating system, then browses them through Furman's existing `local` backend. No native protocol implementation required.

This is the lightweight "OS-mount helper" approach: a mounted share is just a local path, so it reuses existing directory browsing, and `list_volumes`/`eject_volume` already enumerate and unmount network mounts. No `PanelBackend`/`ConnectionProtocol` changes needed.

## How

**Backend** (`src-tauri/src/commands/volumes.rs`, registered in `lib.rs`)
- New async command `mount_network_share(protocol, host, share, username?, password?, domain?) -> mount_point`.
- **macOS:** builds an `smb://`/`nfs://` URL (credentials percent-encoded) and hands it to `open`, which mounts via NetFS under `/Volumes` and reuses the Keychain. New mount detected by snapshotting `/Volumes` before/after.
- **Linux:** `gio mount` (GVfs, unprivileged) for SMB — user/domain in the URL, password on stdin — then locates the share under `/run/user/<uid>/gvfs`. NFS returns a clear "mount manually as root" message.
- Other platforms: clean "not supported yet" error.

**Frontend**
- `src/lib/services/mount.ts` — `invoke` wrapper.
- `src/lib/components/NetworkShareDialog.svelte` — protocol toggle, server, share/export path, optional username/domain/password.
- `panels.svelte.ts` — `mountShare()` mounts then navigates the active panel to the mount point as a `local` folder.
- `ConnectionManager.svelte` — new "Network Share" entry in the sidebar.

## Verification

- `cargo check` ✅ · `eslint` ✅ · `svelte-check` (0 errors/warnings) ✅

## Caveats / scope

- Not yet tested against a live SMB/NFS server (compile/type/lint green only).
- macOS is the solid path; **Linux SMB via `gio` is best-effort** (stdin password prompting is version-dependent).
- **Linux NFS and Windows are out of scope** for this pass.
- One-shot "mount & go" — no saved profiles/Keychain integration for shares yet.