### PR TITLE
ci: fix flaky SeaweedFS S3 tests with retries + pinned image

### DIFF
--- a/.github/workflows/test-s3-seaweedfs.yml
+++ b/.github/workflows/test-s3-seaweedfs.yml
@@ -44,7 +44,7 @@ jobs:
           docker run -d --name seaweedfs \
             -p 8333:8333 -p 9333:9333 \
             -v /tmp/seaweedfs/s3.json:/etc/seaweedfs/s3.json \
-            chrislusf/seaweedfs:latest \
+            chrislusf/seaweedfs:4.37 \
             server -s3 -s3.config=/etc/seaweedfs/s3.json -dir=/data
 
           # Wait for SeaweedFS S3 endpoint to be ready
@@ -77,6 +77,14 @@ jobs:
           S3_TEST_ACCESS_KEY: testkey
           S3_TEST_SECRET_KEY: testsecretkey0123456789
           S3_TEST_REGION: us-east-1
+          # SeaweedFS returns transient 500 InternalError on PutObject during its
+          # warmup window (the S3 gateway accepts connections before the volume
+          # server is ready to serve writes). The SDK marks these retryable; the
+          # default of 3 attempts isn't enough to ride out warmup under -test-threads
+          # concurrency, so crank up retries with adaptive backoff. Read by the AWS
+          # SDK automatically via aws_config::defaults().load().
+          AWS_MAX_ATTEMPTS: "10"
+          AWS_RETRY_MODE: adaptive
         run: |
           cargo test --test s3_integration -- --test-threads=4 \
             --exact \


### PR DESCRIPTION
## Problem

`s3-seaweedfs-tests` fails intermittently on **every branch, including `main`** — most recently on the merge of #107 (an unrelated tauri lockfile bump) and on the rmcp #103 branch. The failures are always a transient `500 InternalError` from SeaweedFS on `PutObject`:

```
Failed to put test object: ... Code: InternalError, status 500,
"We encountered an internal error, please try again." ... retryable: true
```

## Root cause

`cargo test ... --test-threads=4` fires concurrent PutObjects at a **freshly-started** SeaweedFS container. The S3 gateway accepts connections (so the readiness `curl` passes) before the volume server can actually serve writes, so early writes get a transient 500. The SDK classifies these `retryable: true`, but the default of **3 attempts** (~3s window) isn't enough to ride out the warmup under concurrency — so a handful of the 29 tests lose the race each run.

This is unrelated to any application code; it's pure test-infra flakiness.

## Fix

- **`AWS_MAX_ATTEMPTS: 10` + `AWS_RETRY_MODE: adaptive`** in the test step env. These are read automatically by the AWS SDK via `aws_config::defaults().load()` — **no production code change**. 10 attempts with adaptive backoff stretches the retry window well past warmup and adds client-side rate limiting under concurrent load. Fixes all failing paths at once since they all share `build_s3_client`.
- **Pin `chrislusf/seaweedfs:4.37`** (the current `:latest`) for reproducibility.

## Why env, not a per-test retry wrapper

The failures span two code paths — the `put_object` test helper *and* real service code (`put_text`, `upload`). The only shared layer is the SDK client, so fixing retry there covers everything cleanly.