### PR TITLE
Hold TypeScript below v7 in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "description": "Hold TypeScript below v7 until svelte-check and typescript-eslint support the native rewrite",
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<7"
+    }
+  ]
 }


### PR DESCRIPTION
## Why

Renovate proposed TypeScript v7 (#131), the native (Go) compiler rewrite. It can't be adopted yet:

- typescript-eslint (even latest 8.64.0) declares a peer range of `typescript >=4.8.4 <6.1.0`, and `npm run lint` is a required check.
- svelte-check 4.x crashes on startup with TS 7 (`TypeError: Cannot read properties of undefined (reading 'useCaseSensitiveFileNames')`) — confirmed in fenio/anylinuxfs-gui#101.
- The Renovate PR itself had a broken lockfile from a failed `renovate/artifacts` step, so CI fails at `npm ci`.

## What

Add a Renovate `packageRules` entry holding `typescript` at `<7` (same fix as fenio/anylinuxfs-gui#101). TS 6.x minor/patch updates keep flowing; #131 will be closed.

Remove the rule once svelte-check and typescript-eslint support the native rewrite.