### PR TITLE
Fix frozen confirm dialog when deleting a saved connection

### DIFF
--- a/src/lib/components/ConnectionManager.svelte
+++ b/src/lib/components/ConnectionManager.svelte
@@ -44,12 +44,18 @@
 
   function handleDelete(profile: ConnectionProfile) {
     appState.showConfirm(`Delete connection "${profile.name}"?`, async () => {
-      if (profile.type === 's3' && profile.credentialType === 'keychain') {
-        await connectionsState.deleteSecret(profile.id);
-      } else if (profile.type === 'sftp' && profile.authMethod === 'password') {
-        await connectionsState.deleteSecret(profile.id);
+      appState.closeModal();
+      try {
+        if (profile.type === 's3' && profile.credentialType === 'keychain') {
+          await connectionsState.deleteSecret(profile.id);
+        } else if (profile.type === 'sftp' && profile.authMethod === 'password') {
+          await connectionsState.deleteSecret(profile.id);
+        }
+      } catch (err: unknown) {
+        error(String(err));
       }
       connectionsState.removeProfile(profile.id);
+      appState.showConnectionManager();
     });
   }
 


### PR DESCRIPTION
## Bug

In the Connection Manager (cmd+s), clicking Delete on a saved connection and confirming with **Yes** appeared to do nothing — the confirm dialog stayed frozen on screen. Pressing ESC and reopening the manager showed the connection was actually gone.

## Cause

The app has a single modal slot (`appState.modal`). The delete-confirmation callback in `ConnectionManager.svelte` deleted the profile but never called `appState.closeModal()` — unlike every other `showConfirm` callback in the codebase (fileops, editor discard), which close the modal themselves. So the deletion succeeded but the dialog stayed up.

## Fix

- Close the confirm modal immediately on Yes.
- Wrap the keychain secret deletion in try/catch (a keychain error previously aborted the callback silently, leaving the profile undeletable); the profile is now removed regardless and the error is logged.
- Reopen the Connection Manager afterwards so the user lands back in the saved-connections list with the entry removed (previously the confirm dialog had already replaced the manager in the modal slot).

Verified in a dev instance: delete → Yes closes the dialog and returns to the manager with the connection removed. `svelte-check` and `eslint` pass.