### PR TITLE
Show progress for S3/SFTP deletes in the transfer panel

### DIFF
--- a/src-tauri/src/commands/s3.rs
+++ b/src-tauri/src/commands/s3.rs
@@ -377,11 +377,37 @@ pub async fn s3_head_object(
 #[tauri::command]
 pub async fn s3_delete_objects(
     state: State<'_, S3State>,
+    file_op_state: State<'_, FileOpState>,
     id: String,
+    op_id: String,
     keys: Vec<String>,
+    channel: Channel<ProgressEvent>,
 ) -> Result<(), FmError> {
     let service = get_service(&state, &id)?;
-    service.delete_objects(&keys).await
+
+    let flags = Arc::new(crate::commands::file::OpFlags {
+        cancel: AtomicBool::new(false),
+        pause: AtomicBool::new(false),
+    });
+    {
+        let mut map = file_op_state
+            .0
+            .lock()
+            .map_err(|e| FmError::Other(e.to_string()))?;
+        map.insert(op_id.clone(), flags.clone());
+    }
+
+    let result = service
+        .delete_objects(&keys, &op_id, &flags.cancel, &|evt| {
+            let _ = channel.send(evt);
+        })
+        .await;
+
+    if let Ok(mut map) = file_op_state.0.lock() {
+        map.remove(&op_id);
+    }
+
+    result
 }
 
 #[tauri::command]

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -181,7 +181,10 @@ impl FurmanMcp {
         Parameters(params): Parameters<S3DeleteObjectsParams>,
     ) -> Result<String, String> {
         let svc = self.state.get_s3_service(&params.connection_id).map_err(err)?;
-        svc.delete_objects(&params.keys).await.map_err(err)?;
+        let cancel = AtomicBool::new(false);
+        svc.delete_objects(&params.keys, "mcp", &cancel, &|_| {})
+            .await
+            .map_err(err)?;
         Ok(format!("Deleted {} object(s)", params.keys.len()))
     }
 

--- a/src-tauri/src/s3/service.rs
+++ b/src-tauri/src/s3/service.rs
@@ -893,18 +893,35 @@ impl S3Service {
     }
 
     /// Delete S3 objects. For prefix keys, lists and deletes all children.
-    pub async fn delete_objects(&self, keys: &[String]) -> Result<(), FmError> {
-        let mut to_delete: Vec<String> = Vec::new();
+    pub async fn delete_objects(
+        &self,
+        keys: &[String],
+        op_id: &str,
+        cancel: &AtomicBool,
+        on_progress: &(dyn Fn(ProgressEvent) + Send + Sync),
+    ) -> Result<(), FmError> {
+        let mut to_delete: Vec<(String, u64)> = Vec::new();
         for raw_key in keys {
             let key = strip_s3_prefix(raw_key, &self.bucket);
             log::info!("delete_objects: raw={raw_key} stripped={key}");
             if key.ends_with('/') {
+                on_progress(ProgressEvent {
+                    id: op_id.to_string(),
+                    bytes_done: 0,
+                    bytes_total: 0,
+                    current_file: format!("Listing {key}"),
+                    files_done: 0,
+                    files_total: 0,
+                });
                 let children = list_all_objects(&self.client, &self.bucket, &key).await?;
-                for (k, _, _) in children {
-                    to_delete.push(k);
+                for (k, size, _) in children {
+                    to_delete.push((k, size));
                 }
             } else {
-                to_delete.push(key);
+                to_delete.push((key, 0));
+            }
+            if cancel.load(Ordering::Relaxed) {
+                return Err(FmError::Other("Operation cancelled".into()));
             }
         }
         if to_delete.is_empty() {
@@ -912,11 +929,19 @@ impl S3Service {
         }
         log::info!("delete_objects: batch={to_delete:?}");
 
+        let files_total = u32::try_from(to_delete.len()).unwrap_or(u32::MAX);
+        let bytes_total: u64 = to_delete.iter().map(|(_, size)| size).sum();
+        let mut files_done: u32 = 0;
+        let mut bytes_done: u64 = 0;
+
         // Batch delete (max 1000 per request)
         for chunk in to_delete.chunks(1000) {
+            if cancel.load(Ordering::Relaxed) {
+                return Err(FmError::Other("Operation cancelled".into()));
+            }
             let objects: Vec<_> = chunk
                 .iter()
-                .map(|k| {
+                .map(|(k, _)| {
                     aws_sdk_s3::types::ObjectIdentifier::builder()
                         .key(k)
                         .build()
@@ -958,6 +983,17 @@ impl S3Service {
                     .collect();
                 return Err(s3err(format!("Failed to delete: {}", msgs.join("; "))));
             }
+
+            files_done += u32::try_from(chunk.len()).unwrap_or(u32::MAX);
+            bytes_done += chunk.iter().map(|(_, size)| size).sum::<u64>();
+            on_progress(ProgressEvent {
+                id: op_id.to_string(),
+                bytes_done,
+                bytes_total,
+                current_file: format!("Deleted {files_done} of {files_total} objects"),
+                files_done,
+                files_total,
+            });
         }
 
         Ok(())

--- a/src-tauri/tests/s3_integration.rs
+++ b/src-tauri/tests/s3_integration.rs
@@ -172,7 +172,7 @@ async fn test_delete_objects() {
 
     // Delete single file
     ctx.service
-        .delete_objects(&["del1.txt".to_string()])
+        .delete_objects(&["del1.txt".to_string()], "test", &AtomicBool::new(false), &|_| {})
         .await
         .expect("delete single failed");
 
@@ -188,7 +188,7 @@ async fn test_delete_objects() {
 
     // Delete prefix (folder)
     ctx.service
-        .delete_objects(&["delfolder/".to_string()])
+        .delete_objects(&["delfolder/".to_string()], "test", &AtomicBool::new(false), &|_| {})
         .await
         .expect("delete prefix failed");
 

--- a/src/lib/actions/fileops.ts
+++ b/src/lib/actions/fileops.ts
@@ -6,8 +6,8 @@ import { transfersState } from '$lib/state/transfers.svelte';
 import { connectionsState } from '$lib/state/connections.svelte';
 import { clipboardState } from '$lib/state/clipboard.svelte';
 import { checkConflicts, deleteFilesUndoable, renameFile, createDirectory } from '$lib/services/tauri';
-import { s3DeleteObjects, s3RenameObject, s3CreateFolder, s3IsObjectEncrypted, type EncryptionConfig } from '$lib/services/s3';
-import { sftpDelete, sftpRename, sftpCreateFolder } from '$lib/services/sftp';
+import { s3RenameObject, s3CreateFolder, s3IsObjectEncrypted, type EncryptionConfig } from '$lib/services/s3';
+import { sftpRename, sftpCreateFolder } from '$lib/services/sftp';
 import { error } from '$lib/services/log';
 
 // ── Encryption helpers ──────────────────────────────────────────────────────
@@ -394,42 +394,37 @@ export async function handleDelete() {
     appState.closeModal();
     const fileCount = sources.length;
     const backend = active.backend;
+    if ((backend === 's3' && active.s3Connection) || (backend === 'sftp' && active.sftpConnection)) {
+      transfersState.enqueue({
+        id: 'delete-' + Date.now() + '-' + Math.random().toString(36).slice(2, 6),
+        type: 'delete',
+        sources,
+        destination: active.path,
+        srcBackend: backend,
+        destBackend: backend,
+        s3SrcConnectionId: active.s3Connection?.connectionId,
+        sftpSrcConnectionId: active.sftpConnection?.connectionId,
+      });
+      return;
+    }
     try {
-      if (backend === 's3' && active.s3Connection) {
-        await s3DeleteObjects(active.s3Connection.connectionId, sources);
-      } else if (backend === 'sftp' && active.sftpConnection) {
-        await sftpDelete(active.sftpConnection.connectionId, sources);
-      } else {
-        const trashItems = await deleteFilesUndoable(sources);
-        operationsState.push({
-          id: Date.now().toString(36),
-          type: 'delete',
-          timestamp: Date.now(),
-          backend: 'local',
-          trashItems,
-          sourcePaths: sources,
-          undone: false,
-        });
-        statusState.setMessage(`Deleted ${fileCount} file(s)`);
-        await active.loadDirectory(active.path);
-        return;
-      }
+      const trashItems = await deleteFilesUndoable(sources);
+      operationsState.push({
+        id: Date.now().toString(36),
+        type: 'delete',
+        timestamp: Date.now(),
+        backend: 'local',
+        trashItems,
+        sourcePaths: sources,
+        undone: false,
+      });
+      statusState.setMessage(`Deleted ${fileCount} file(s)`);
+      await active.loadDirectory(active.path);
     } catch (err: unknown) {
       error(String(err));
       appState.showAlert('Delete failed: ' + String(err));
       await active.loadDirectory(active.path);
-      return;
     }
-    operationsState.push({
-      id: Date.now().toString(36),
-      type: 'delete',
-      timestamp: Date.now(),
-      backend,
-      sourcePaths: sources,
-      undone: false,
-    });
-    statusState.setMessage(`Deleted ${fileCount} file(s)`);
-    await active.loadDirectory(active.path);
   });
 }
 

--- a/src/lib/actions/sync.ts
+++ b/src/lib/actions/sync.ts
@@ -113,7 +113,7 @@ export async function executeSyncDeletes(
 
   try {
     if (destBackend === 's3') {
-      await s3DeleteObjects(destS3Id, deletePaths);
+      await s3DeleteObjects(destS3Id, 'sync-del-' + Date.now(), deletePaths);
     } else if (destBackend === 'sftp') {
       const sftpId = panels.active.backend === 'sftp' ? panels.active.sftpConnection?.connectionId : panels.inactive.sftpConnection?.connectionId;
       if (sftpId) await sftpDelete(sftpId, deletePaths);

--- a/src/lib/components/TransferPanel.svelte
+++ b/src/lib/components/TransferPanel.svelte
@@ -17,6 +17,7 @@
       case 'copy': return 'Copy';
       case 'move': return 'Move';
       case 'extract': return 'Extract';
+      case 'delete': return 'Delete';
       default: return type;
     }
   }
@@ -26,6 +27,7 @@
       case 'copy': return 'Copied';
       case 'move': return 'Moved';
       case 'extract': return 'Extracted';
+      case 'delete': return 'Deleted';
       default: return type;
     }
   }
@@ -35,6 +37,7 @@
       case 'copy': return 'Copying';
       case 'move': return 'Moving';
       case 'extract': return 'Extracting';
+      case 'delete': return 'Deleting';
       default: return type;
     }
   }
@@ -42,11 +45,13 @@
   function transferLabel(t: { type: string; status: TransferStatus; sources: string[]; destination: string; error?: string }): string {
     const count = t.sources.length;
     const dest = t.destination.split('/').filter(Boolean).pop() ?? t.destination;
+    // Deletes have no destination — omit the "to <dest>" suffix
+    const toDest = t.type === 'delete' ? '' : ` to ${dest}`;
     if (t.status === 'running') {
-      return `${typeLabelActive(t.type)} ${count} item(s) to ${dest}`;
+      return `${typeLabelActive(t.type)} ${count} item(s)${toDest}`;
     }
     if (t.status === 'completed') {
-      return `${typeLabelPast(t.type)} ${count} item(s) to ${dest}`;
+      return `${typeLabelPast(t.type)} ${count} item(s)${toDest}`;
     }
     if (t.status === 'cancelled') {
       return `${typeLabel(t.type)} cancelled`;
@@ -55,10 +60,10 @@
       return `${typeLabel(t.type)} failed: ${t.error ?? 'unknown error'}`;
     }
     if (t.status === 'paused') {
-      return `${typeLabel(t.type)} paused — ${count} item(s) to ${dest}`;
+      return `${typeLabel(t.type)} paused — ${count} item(s)${toDest}`;
     }
     if (t.status === 'queued') {
-      return `${typeLabel(t.type)} queued — ${count} item(s) to ${dest}`;
+      return `${typeLabel(t.type)} queued — ${count} item(s)${toDest}`;
     }
     return typeLabel(t.type);
   }
@@ -186,7 +191,9 @@
         {/if}
         <div class="transfer-actions">
           {#if t.status === 'running'}
-            <button class="tp-btn" onclick={() => transfersState.pause(t.id)}>Pause</button>
+            {#if t.type !== 'delete'}
+              <button class="tp-btn" onclick={() => transfersState.pause(t.id)}>Pause</button>
+            {/if}
             <button class="tp-btn tp-btn-cancel" onclick={() => transfersState.cancel(t.id)}>Cancel</button>
           {:else if t.status === 'paused'}
             <button class="tp-btn" onclick={() => transfersState.resume(t.id)}>Resume</button>

--- a/src/lib/services/s3.ts
+++ b/src/lib/services/s3.ts
@@ -135,9 +135,13 @@ export async function s3HeadObject(
 
 export async function s3DeleteObjects(
   id: string,
-  keys: string[]
+  opId: string,
+  keys: string[],
+  onProgress?: (e: ProgressEvent) => void
 ): Promise<void> {
-  await invoke('s3_delete_objects', { id, keys });
+  const channel = new Channel<ProgressEvent>();
+  if (onProgress) channel.onmessage = onProgress;
+  await invoke('s3_delete_objects', { id, opId, keys, channel });
 }
 
 export async function s3CreateFolder(id: string, key: string): Promise<void> {

--- a/src/lib/state/transfers.svelte.ts
+++ b/src/lib/state/transfers.svelte.ts
@@ -5,7 +5,7 @@ import { sftpDownload, sftpUpload, sftpDelete } from '$lib/services/sftp';
 import { formatSize } from '$lib/utils/format';
 
 export type TransferStatus = 'queued' | 'running' | 'paused' | 'completed' | 'failed' | 'cancelled';
-type TransferType = 'copy' | 'move' | 'extract';
+type TransferType = 'copy' | 'move' | 'extract' | 'delete';
 
 export interface Transfer {
   id: string;
@@ -182,7 +182,7 @@ class TransfersState {
     if (!this.hasActive && this.queued.length === 0) {
       this.dialogVisible = false;
     }
-    window.dispatchEvent(new CustomEvent('transfer-done', { detail: { type: t?.type, destination: t?.destination, srcFocusName: t?.srcFocusName } }));
+    window.dispatchEvent(new CustomEvent('transfer-done', { detail: { type: t?.type, destination: t?.destination, srcFocusName: t?.srcFocusName, count: t?.sources.length } }));
   }
 
   fail(id: string, error: string) {
@@ -304,6 +304,12 @@ class TransfersState {
         await extractArchive(t.id, t.archivePath, t.archiveInternalPaths, t.destination, onProgress);
       } else if (t.type === 'copy' || t.type === 'move') {
         result = await this.dispatchCopyMove(t, onProgress);
+      } else if (t.type === 'delete') {
+        if (t.srcBackend === 's3') {
+          await s3DeleteObjects(t.s3SrcConnectionId!, t.id, t.sources, onProgress);
+        } else if (t.srcBackend === 'sftp') {
+          await sftpDelete(t.sftpSrcConnectionId!, t.sources);
+        }
       }
 
       // Check if paused (backend returned checkpoint)
@@ -394,7 +400,7 @@ class TransfersState {
       // S3 move = copy/download + delete source
       if (srcBackend === 's3' && destBackend === 'local') {
         const result = await s3Download(t.s3SrcConnectionId!, t.id, t.sources, t.destination, onProgress, t.encryptionPassword);
-        await s3DeleteObjects(t.s3SrcConnectionId!, t.sources);
+        await s3DeleteObjects(t.s3SrcConnectionId!, t.id + '-del', t.sources);
         return result;
       }
       if (srcBackend === 'local' && destBackend === 's3') {
@@ -412,7 +418,7 @@ class TransfersState {
           t.s3SrcConnectionId!, t.id, t.sources,
           t.s3DestConnectionId!, t.s3DestPrefix!, onProgress,
         );
-        await s3DeleteObjects(t.s3SrcConnectionId!, t.sources);
+        await s3DeleteObjects(t.s3SrcConnectionId!, t.id + '-del', t.sources);
         return result;
       }
       // SFTP move = download/upload + delete source
@@ -446,7 +452,7 @@ class TransfersState {
           return `${tempDir}/${name}`;
         });
         const result = await sftpUpload(t.sftpDestConnectionId!, t.id + '-up', downloaded, t.sftpDestPath!, onProgress);
-        await s3DeleteObjects(t.s3SrcConnectionId!, t.sources);
+        await s3DeleteObjects(t.s3SrcConnectionId!, t.id + '-del', t.sources);
         return result;
       }
       if (srcBackend === 'sftp' && destBackend === 's3') {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -541,8 +541,22 @@
   window.addEventListener('native-drag-drop', handleNativeDragDrop);
 
   function handleTransferDone(e: Event) {
-    const { type, destination, srcFocusName } = (e as CustomEvent).detail ?? {};
+    const { type, destination, srcFocusName, count } = (e as CustomEvent).detail ?? {};
     const reloads: Promise<void>[] = [];
+
+    if (type === 'delete') {
+      // For deletes, destination is the directory the entries were deleted from
+      if (typeof count === 'number' && count > 0) {
+        statusState.setMessage(`Deleted ${count} file(s)`);
+      }
+      for (const p of [panels.left, panels.right]) {
+        if (p.path === destination && p.backend !== 'archive') {
+          reloads.push(p.loadDirectory(p.path));
+        }
+      }
+      Promise.all(reloads);
+      return;
+    }
 
     // Figure out which panel is the destination based on its current path
     const destIsLeft = destination && panels.left.path === destination;


### PR DESCRIPTION
## Problem

Deleting large S3 directories ran as a silent one-shot `s3_delete_objects` call — no progress, no status, nothing in the transfer panel. For big prefixes this meant a minute or more of apparent inactivity.

## Changes

**Backend**
- `S3Service::delete_objects` now takes an op id, cancel flag, and progress callback. It emits "Listing <prefix>" events while expanding directory prefixes, then per 1000-object batch reports objects deleted and bytes (sizes come from the listing), and checks the cancel flag between listings/batches.
- The `s3_delete_objects` command registers the operation in the shared `FileOpState` cancel registry (same as copy/move) and streams progress over a `Channel<ProgressEvent>`, so Cancel in the transfer panel genuinely aborts between batches.
- MCP delete tool updated for the new signature (no-op progress).

**Frontend**
- `handleDelete` for S3/SFTP enqueues a `delete` transfer instead of awaiting inline. New `delete` transfer type dispatches to the respective backend.
- TransferPanel: Deleting/Deleted/Delete labels (no "to <dest>" suffix), bytes/files progress bars, and "Deleted X of Y objects" text; Pause is hidden for deletes (batch deletes can't pause), Cancel works for S3.
- On completion the panel(s) showing the deleted-from directory reload and the status bar shows "Deleted N file(s)". Failures surface as a failed transfer entry (consistent with copy/move) instead of a blocking alert.
- SFTP deletes go through the queue too so they're visible while running, but without progress events (backend doesn't emit any yet — possible follow-up).

Local deletes are unchanged (trash + undo).

## Testing

Verified in a dev instance against a real bucket: deleting large directories shows live progress in the transfer panel and the panel refreshes on completion. `cargo check`, `svelte-check` (0 errors), and `eslint` pass.