### PR TITLE
Remove leftover debug traces logged at ERROR level

### DIFF
--- a/src/lib/components/FileIcon.svelte
+++ b/src/lib/components/FileIcon.svelte
@@ -83,7 +83,6 @@
       const isMove = ev.shiftKey;
       const mode = isMove ? 'move' : 'copy';
       dragState.source = { side: dragSide, backend: dragBackend, paths, s3ConnectionId: dragS3Id, sftpConnectionId: dragSftpId, isMove };
-      logError(`[drag] FileIcon SET dragState.source side=${dragSide} isMove=${isMove} paths=${paths.length}`);
 
       // Lock scrolling on the source panel to prevent macOS auto-scroll during drag
       const srcList = (ev.target as Element)?.closest('.file-list') as HTMLElement | null;

--- a/src/lib/components/FileRow.svelte
+++ b/src/lib/components/FileRow.svelte
@@ -174,7 +174,6 @@
       const isMove = ev.shiftKey;
       const mode = isMove ? 'move' : 'copy';
       dragState.source = { side: dragSide, backend: dragBackend, paths, s3ConnectionId: dragS3Id, sftpConnectionId: dragSftpId, isMove };
-      logError(`[drag] FileRow SET dragState.source side=${dragSide} isMove=${isMove} paths=${paths.length}`);
 
       // Lock scrolling on the source panel to prevent macOS auto-scroll during drag
       const srcList = (ev.target as Element)?.closest('.file-list') as HTMLElement | null;

--- a/src/lib/state/panels.svelte.ts
+++ b/src/lib/state/panels.svelte.ts
@@ -6,7 +6,6 @@ import { s3Connect, s3Disconnect, s3ListObjects, s3IsObjectEncrypted } from '$li
 import { sftpConnect, sftpDisconnect, sftpListObjects } from '$lib/services/sftp';
 import { mountNetworkShare } from '$lib/services/mount';
 import { appState } from '$lib/state/app.svelte';
-import { error as logError } from '$lib/services/log';
 
 /// Threshold above which we use streamed directory listing.
 const STREAM_THRESHOLD = 50_000;
@@ -204,7 +203,6 @@ export class PanelData {
       if (cursorName) {
         const idx = this.filteredSortedEntries.findIndex((e) => e.name === cursorName);
         const newIdx = idx >= 0 ? idx : Math.max(0, this.filteredSortedEntries.length - 1);
-        logError(`[refresh] cursorName=${cursorName} idx=${idx} newIdx=${newIdx} total=${this.filteredSortedEntries.length}`);
         this.cursorIndex = newIdx;
       } else if (this.cursorIndex >= this.filteredSortedEntries.length) {
         this.cursorIndex = Math.max(0, this.filteredSortedEntries.length - 1);
@@ -278,10 +276,8 @@ export class PanelData {
       if (focusName) {
         const sorted = sortEntries(this.entries, this.sortField, this.sortDirection);
         const idx = sorted.findIndex((e) => e.name === focusName);
-        logError(`[loadDirectory] focusName=${focusName} idx=${idx} total=${sorted.length}`);
         this.cursorIndex = idx >= 0 ? idx : 0;
       } else {
-        logError(`[loadDirectory] no focusName, cursor=0`);
         this.cursorIndex = 0;
       }
     } catch (err: unknown) {
@@ -337,10 +333,8 @@ export class PanelData {
           if (focusName) {
             const sorted = sortEntries(this.entries, this.sortField, this.sortDirection);
             const idx = sorted.findIndex((e) => e.name === focusName);
-            logError(`[loadDirectoryStreamed] focusName=${focusName} idx=${idx} total=${sorted.length}`);
             this.cursorIndex = idx >= 0 ? idx : 0;
           } else {
-            logError(`[loadDirectoryStreamed] no focusName, cursor=0`);
             this.cursorIndex = 0;
           }
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -102,7 +102,6 @@
           return;
         }
         if (event.payload.type === 'drop') {
-          error(`[drag] onDragDropEvent drop: _dropProcessed=${_dropProcessed} src=${JSON.stringify(dragState.source)}`);
           // Skip if this is an internal drag (handled by handleNativeDragDrop)
           if (_dropProcessed || dragState.source) {
             _dropProcessed = false;
@@ -490,7 +489,6 @@
     const { x, y } = (e as CustomEvent).detail;
     const result = getTargetPanel({ x, y });
     const src = dragState.source;
-    error(`[drag] handleNativeDragDrop: src=${JSON.stringify(src)} tgt=${result?.side}`);
     if (!result || !src || src.side === result.side) {
       dragState.source = null;
       clearDragOverHighlight();
@@ -512,7 +510,6 @@
     const dragIdx = entries.findIndex((e) => e.name === draggedName);
     const neighbor = dragIdx >= 0 ? (entries[dragIdx + 1] ?? entries[dragIdx - 1]) : null;
     const srcFocusName = neighbor?.name;
-    error(`[drag] enqueue: type=${transferType} dest=${dest} srcFocusName=${srcFocusName}`);
 
     dragState.source = null;
 
@@ -563,7 +560,6 @@
     const destIsRight = destination && panels.right.path === destination;
     const destPanel = destIsLeft ? panels.left : destIsRight ? panels.right : null;
     const srcPanel = destIsLeft ? panels.right : destIsRight ? panels.left : null;
-    error(`[drag] transferDone: type=${type} dest=${destination} srcFocusName=${srcFocusName} destPanel=${destPanel ? (destIsLeft ? 'left' : 'right') : 'null'}`);
 
     if (type === 'copy') {
       // Only reload destination panel


### PR DESCRIPTION
Removes 11 leftover troubleshooting logs from the drag-and-drop and cursor-preservation work. They logged routine events (every directory load, every drag) via `error()`, spamming the dev console and the persisted rotating log file in production (the log level filter is Info, so ERROR always passes).

Genuine error logging (`.catch((err) => logError(...))` etc.) is untouched; the now-unused import in `panels.svelte.ts` is dropped.

`svelte-check` and `eslint` pass.