### PR TITLE
Reconstruct changelog for 0.3.3–0.3.11 and fix release notes generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,12 +77,19 @@ jobs:
       - name: Upload furman-mcp release asset
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_BODY: ${{ needs.changelog.outputs.body }}
         run: |
           cp src-tauri/target/${{ matrix.target }}/release/furman-mcp ${{ matrix.mcp_asset }}
-          # Ensure release exists (tauri-action creates it later, but we need it now)
-          gh release view "${{ github.ref_name }}" --repo "${{ github.repository }}" >/dev/null 2>&1 || \
+          # Ensure release exists with the changelog as its body (tauri-action
+          # creates it later, but we need it now — and it does not update the
+          # body of an already-existing release). "|| true" tolerates the race
+          # where the other matrix job creates it between view and create.
+          if ! gh release view "${{ github.ref_name }}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            printf '%s' "$RELEASE_BODY" > release-notes.md
             gh release create "${{ github.ref_name }}" --repo "${{ github.repository }}" \
-              --title "Furman ${{ github.ref_name }}" --draft=false --prerelease=false
+              --title "Furman ${{ github.ref_name }}" --notes-file release-notes.md \
+              --draft=false --prerelease=false || true
+          fi
           gh release upload "${{ github.ref_name }}" "${{ matrix.mcp_asset }}" \
             --repo "${{ github.repository }}" --clobber
 
@@ -103,6 +110,31 @@ jobs:
           releaseDraft: false
           prerelease: false
           args: --target ${{ matrix.target }}
+
+  update-changelog:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Prepend latest release notes to CHANGELOG.md
+        uses: orhun/git-cliff-action@v4
+        with:
+          args: --latest --prepend CHANGELOG.md
+
+      - name: Commit and push changelog
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git diff --cached --quiet || {
+            git commit -m "Update CHANGELOG.md for ${GITHUB_REF_NAME}"
+            git push origin HEAD:main
+          }
 
   update-homebrew:
     needs: build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,118 @@
 # Changelog
 
+## [0.3.11] - 2026-06-21
+
+### Added
+
+- Add eject button to sidebar devices
+- Add in-app SMB/NFS network share mounting
+
+### Dependencies
+
+- 48 dependency update(s) via Renovate
+
+## [0.3.10] - 2026-05-23
+
+### Added
+
+- Add frontend CI workflow
+
+### Fixed
+
+- Fix existing svelte eslint errors
+
+### Changed
+
+- Migrate from keyring v3 to keyring-core + per-platform stores
+
+### Dependencies
+
+- 29 dependency update(s) via Renovate
+
+### Other
+
+- Adapt SFTP agent auth to russh 0.61 AgentIdentity enum
+- Adapt s3::crypto to rand 0.10 API
+- Switch from deprecated md5::Context::compute to finalize
+- Enable crypto-rust and vendored features on dbus-secret-service-keyring-store
+- Surface remote-connection failures instead of swallowing them
+
+## [0.3.9] - 2026-03-27
+
+### Fixed
+
+- Fix missing agent_socket param in test helper
+- Fix missing agent_socket param in MCP server
+
+### Other
+
+- Custom SSH agent socket path, dependency updates
+
+## [0.3.8] - 2026-03-18
+
+### Other
+
+- Large directory performance (1M+ files)
+
+## [0.3.7] - 2026-03-18
+
+### Fixed
+
+- Fix paste in S3 dialog, disable autocomplete in input fields
+
+## [0.3.6] - 2026-03-17
+
+### Fixed
+
+- Fix package-lock.json out of sync with package.json
+
+### Other
+
+- Viewer search mode, Nix support, dependency updates
+
+## [0.3.5] - 2026-03-15
+
+### Changed
+
+- Update README: macOS only (remove Linux references)
+
+### Other
+
+- Remove .beads directory from repo
+- Disk Usage two-way sync, deep caching, and dependency updates
+
+## [0.3.4] - 2026-03-07
+
+### Added
+
+- Add drag-and-drop onto directory rows, fix data loss and DnD issues
+
+### Fixed
+
+- Fix package-lock.json sync for CI
+- Fix release CI: create release before uploading MCP assets
+
+### Other
+
+- Open archives from SFTP/S3, add download size prompt and overwrite shortcut
+- Remove Linux build from release CI (macOS only for now)
+
+## [0.3.3] - 2026-03-04
+
+### Added
+
+- Add model inspector enhancements: VRAM estimation, comparison, tensor visualization
+- Add MCP server for S3 and SFTP operations
+- Add model inspector command and frontend wiring
+- Add MCP server documentation and link from README
+- Add disk usage analyzer and bump version to 0.3.3
+- Add --help/--version to furman-mcp and Homebrew formula
+
+### Fixed
+
+- Fix release CI: build furman-mcp binary before bundling
+- Fix release CI: enable mcp feature for furman-mcp build
+
 ## 0.3.2
 
 ### Added

--- a/cliff.toml
+++ b/cliff.toml
@@ -10,24 +10,36 @@ body = """
 {% endif %}\
 {% for group, commits in commits | group_by(attribute="group") %}
     ### {{ group | striptags | trim | upper_first }}
-    {% for commit in commits %}
-        - {{ commit.message }}\
-    {% endfor %}
+    {% if "Dependencies" in group %}
+        - {{ commits | length }} dependency update(s) via Renovate\
+    {% else %}\
+        {% for commit in commits %}
+        - {{ commit.message | split(pat="\n") | first | trim }}\
+        {% endfor %}\
+    {% endif %}
 {% endfor %}\n
 """
 trim = true
 
 [git]
 conventional_commits = false
+commit_preprocessors = [
+    # Strip "vX.Y.Z: " prefixes from release-bump commits
+    { pattern = '^v\d+\.\d+\.\d+: ', replace = "" },
+]
 commit_parsers = [
-    { message = "^Add ", group = "Added", default_scope = "", scope = "" },
-    { message = "^feat", group = "Added" },
-    { message = "^Fix ", group = "Fixed" },
-    { message = "^fix", group = "Fixed" },
-    { message = "^Update ", group = "Changed" },
-    { message = "^Migrate ", group = "Changed" },
-    { message = "^Refactor ", group = "Changed" },
-    { message = "^refactor", group = "Changed" },
-    { message = "^Change ", group = "Changed" },
-    { message = ".*", group = "Other" },
+    { message = "^Merge (pull request|branch)", skip = true },
+    { message = "^Bump version", skip = true },
+    { message = "^bd: ", skip = true },
+    { message = '^Update (Rust crate|dependency|.+ monorepo|\S+/\S+ action)', group = "<!-- 3 -->Dependencies" },
+    { message = "^Add ", group = "<!-- 0 -->Added" },
+    { message = "^feat", group = "<!-- 0 -->Added" },
+    { message = "^Fix ", group = "<!-- 1 -->Fixed" },
+    { message = "^fix", group = "<!-- 1 -->Fixed" },
+    { message = "^Update ", group = "<!-- 2 -->Changed" },
+    { message = "^Migrate ", group = "<!-- 2 -->Changed" },
+    { message = "^Refactor ", group = "<!-- 2 -->Changed" },
+    { message = "^refactor", group = "<!-- 2 -->Changed" },
+    { message = "^Change ", group = "<!-- 2 -->Changed" },
+    { message = ".*", group = "<!-- 4 -->Other" },
 ]


### PR DESCRIPTION
## Problem

Every release since v0.3.5 (except hand-edited v0.3.6) has an empty body, and CHANGELOG.md stops at 0.3.2. Root cause: the early `gh release create` added for MCP asset uploads (d0fa731) creates the release without notes, and `tauri-action` does not update the body of an already-existing release — so the git-cliff output computed by the `changelog` job was silently dropped.

## Changes

- **release.yml**: the early `gh release create` now receives the git-cliff output via `--notes-file`; a `|| true` tolerates the create race between the two matrix jobs. New `update-changelog` job runs after a successful build and prepends the release's section to CHANGELOG.md on `main` (`git-cliff --latest --prepend`), so the changelog file stays current automatically.
- **cliff.toml**: only the first line of each commit message is used (v0.3.3's release body shows what full bodies look like); merge commits, version bumps, and `bd:` backup commits are skipped; Renovate updates collapse into a one-line Dependencies count; sections are ordered Added / Fixed / Changed / Dependencies / Other.
- **CHANGELOG.md**: reconstructed sections for 0.3.3 through 0.3.11, generated from git history with the new config.

The empty GitHub release bodies (v0.3.5, v0.3.7–v0.3.11) are backfilled separately via `gh release edit` with the same content.