### PR TITLE
Fix critical remote operation safety

### DIFF
--- a/.github/workflows/test-sftp.yml
+++ b/.github/workflows/test-sftp.yml
@@ -31,6 +31,20 @@ jobs:
             sleep 1
           done
 
+          # Trust only the ephemeral server created for this CI job.
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          for i in $(seq 1 30); do
+            if ssh-keyscan -p 2222 localhost > ~/.ssh/known_hosts 2>/dev/null; then
+              chmod 600 ~/.ssh/known_hosts
+              echo "SFTP test server key enrolled"
+              break
+            fi
+            echo "Waiting for SFTP host key... ($i/30)"
+            sleep 1
+          done
+          test -s ~/.ssh/known_hosts
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 

--- a/docs/sftp.md
+++ b/docs/sftp.md
@@ -14,6 +14,17 @@ Enter the host, port (default 22), and username, then click **Connect** or **Sav
 
 Saved SFTP connections appear in the Connection Manager sidebar. Press **Cmd+S** again while connected to disconnect.
 
+### Host key verification
+
+Furman verifies SSH server keys against `~/.ssh/known_hosts`. Unknown or changed keys are rejected. Before connecting to a new server, verify its fingerprint through a trusted channel and add it with OpenSSH, for example:
+
+```sh
+ssh-keyscan -p 22 example.com | ssh-keygen -lf -
+ssh-keyscan -p 22 example.com >> ~/.ssh/known_hosts
+```
+
+Replace `22` with the configured SSH port. Do not add a key until its displayed fingerprint matches the server administrator's fingerprint.
+
 ## Browsing & Navigation
 
 - Browse remote directories with standard dual-pane navigation

--- a/src-tauri/src/commands/sftp.rs
+++ b/src-tauri/src/commands/sftp.rs
@@ -207,9 +207,16 @@ pub async fn sftp_download(
         .collect();
 
     let result = svc
-        .download(&remote_paths, &destination, &op_id, &flags.cancel, &|evt| {
-            let _ = channel.send(evt);
-        })
+        .download_with_pause(
+            &remote_paths,
+            &destination,
+            &op_id,
+            &flags.cancel,
+            &flags.pause,
+            &|evt| {
+                let _ = channel.send(evt);
+            },
+        )
         .await;
 
     // Clean up
@@ -246,9 +253,16 @@ pub async fn sftp_upload(
     let remote_dest = strip_sftp_prefix(&remote_prefix);
 
     let result = svc
-        .upload(&sources, remote_dest, &op_id, &flags.cancel, &|evt| {
-            let _ = channel.send(evt);
-        })
+        .upload_with_pause(
+            &sources,
+            remote_dest,
+            &op_id,
+            &flags.cancel,
+            &flags.pause,
+            &|evt| {
+                let _ = channel.send(evt);
+            },
+        )
         .await;
 
     // Clean up

--- a/src-tauri/src/sftp/client.rs
+++ b/src-tauri/src/sftp/client.rs
@@ -31,19 +31,35 @@ pub struct SftpConnection {
 
 // ── SSH Handler ──────────────────────────────────────────────────────────────
 
-/// Minimal SSH client handler — accepts all host keys (TODO: known_hosts).
-pub struct SshHandler;
+/// SSH client handler that verifies server keys against ~/.ssh/known_hosts.
+pub struct SshHandler {
+    host: String,
+    port: u16,
+}
 
 impl client::Handler for SshHandler {
     type Error = russh::Error;
 
     fn check_server_key(
         &mut self,
-        _server_public_key: &ssh_key::PublicKey,
+        server_public_key: &ssh_key::PublicKey,
     ) -> impl Future<Output = Result<bool, Self::Error>> + Send {
-        // Accept all host keys for now
-        // TODO: implement known_hosts verification
-        std::future::ready(Ok(true))
+        let result = russh::keys::known_hosts::known_host_keys(&self.host, self.port)
+            .map_err(russh::Error::from)
+            .and_then(|known_keys| {
+                if known_keys
+                    .iter()
+                    .any(|(_, known_key)| known_key == server_public_key)
+                {
+                    Ok(true)
+                } else if let Some((line, _)) = known_keys.first() {
+                    Err(russh::Error::KeyChanged { line: *line })
+                } else {
+                    Ok(false)
+                }
+            });
+
+        std::future::ready(result)
     }
 }
 
@@ -70,7 +86,10 @@ pub async fn build_sftp_client(
         ..Default::default()
     };
 
-    let handler = SshHandler;
+    let handler = SshHandler {
+        host: host.to_owned(),
+        port,
+    };
     let mut handle = client::connect(Arc::new(config), (host, port), handler)
         .await
         .map_err(|e| sftperr(format!("SSH connect failed: {e}")))?;

--- a/src-tauri/src/sftp/service.rs
+++ b/src-tauri/src/sftp/service.rs
@@ -219,6 +219,20 @@ impl SftpService {
         cancel: &AtomicBool,
         on_progress: &(dyn Fn(ProgressEvent) + Send + Sync),
     ) -> Result<Option<TransferCheckpoint>, FmError> {
+        let pause = AtomicBool::new(false);
+        self.download_with_pause(remote_paths, local_dest, op_id, cancel, &pause, on_progress)
+            .await
+    }
+
+    pub async fn download_with_pause(
+        &self,
+        remote_paths: &[String],
+        local_dest: &str,
+        op_id: &str,
+        cancel: &AtomicBool,
+        pause: &AtomicBool,
+        on_progress: &(dyn Fn(ProgressEvent) + Send + Sync),
+    ) -> Result<Option<TransferCheckpoint>, FmError> {
         // Send an initial "scanning" progress event so the UI shows activity
         on_progress(ProgressEvent {
             id: op_id.to_string(),
@@ -267,8 +281,10 @@ impl SftpService {
                     clean,
                     file_list.len()
                 );
-            } else {
+            } else if meta.is_regular() {
                 file_list.push((clean.to_string(), local_target, meta.size.unwrap_or(0)));
+            } else {
+                return Err(sftperr(format!("unsupported remote file type: '{clean}'")));
             }
 
             // Report scanning progress so the UI stays responsive
@@ -290,10 +306,20 @@ impl SftpService {
         let files_total = file_list.len() as u32;
         let mut bytes_done: u64 = 0;
         let mut files_done: u32 = 0;
+        let mut completed_files: Vec<String> = Vec::new();
 
         for (remote, local, _size) in &file_list {
             if cancel.load(Ordering::Relaxed) {
                 return Err(FmError::Other("cancelled".into()));
+            }
+            if pause.load(Ordering::Relaxed) {
+                return Ok(Some(TransferCheckpoint {
+                    files_completed: completed_files,
+                    bytes_done,
+                    bytes_total,
+                    files_done,
+                    files_total,
+                }));
             }
 
             // Ensure parent directory exists
@@ -317,22 +343,7 @@ impl SftpService {
             .await
             {
                 Ok(Ok(d)) => d,
-                Ok(Err(e)) => {
-                    log::warn!("SFTP download: read '{remote}' failed: {e}, skipping");
-                    files_done += 1;
-                    on_progress(ProgressEvent {
-                        id: op_id.to_string(),
-                        bytes_done,
-                        bytes_total,
-                        current_file: format!(
-                            "Skipped: {}",
-                            remote.rsplit('/').next().unwrap_or(remote)
-                        ),
-                        files_done,
-                        files_total,
-                    });
-                    continue;
-                }
+                Ok(Err(e)) => return Err(sftperr(format!("read '{remote}': {e}"))),
                 Err(_) => {
                     log::error!(
                         "SFTP download: read '{remote}' timed out after {}s — connection likely dead",
@@ -349,6 +360,7 @@ impl SftpService {
 
             bytes_done += data.len() as u64;
             files_done += 1;
+            completed_files.push(remote.clone());
 
             on_progress(ProgressEvent {
                 id: op_id.to_string(),
@@ -373,15 +385,12 @@ impl SftpService {
         on_progress: &(dyn Fn(ProgressEvent) + Send + Sync),
     ) -> Result<(), FmError> {
         log::info!("SFTP collect: readdir '{remote_dir}'");
-        let entries = match self.session.read_dir(remote_dir).await {
-            Ok(iter) => iter.collect::<Vec<_>>(),
-            Err(e) => {
-                log::warn!(
-                    "SFTP collect: readdir '{remote_dir}' failed: {e}, skipping"
-                );
-                return Ok(());
-            }
-        };
+        let entries = self
+            .session
+            .read_dir(remote_dir)
+            .await
+            .map_err(|e| sftperr(format!("readdir '{remote_dir}': {e}")))?
+            .collect::<Vec<_>>();
         log::info!(
             "SFTP collect: '{}' has {} entries",
             remote_dir,
@@ -412,15 +421,11 @@ impl SftpService {
                         out.push((remote_child, local_child, verified.size.unwrap_or(0)));
                     }
                     Ok(_) => {
-                        log::info!(
-                            "SFTP collect: '{remote_child}' is not a regular file or dir, skipping"
-                        );
+                        return Err(sftperr(format!(
+                            "unsupported remote file type: '{remote_child}'"
+                        )));
                     }
-                    Err(e) => {
-                        log::warn!(
-                            "SFTP collect: stat '{remote_child}' failed: {e}, skipping"
-                        );
-                    }
+                    Err(e) => return Err(sftperr(format!("stat '{remote_child}': {e}"))),
                 }
             } else if meta.is_regular() {
                 out.push((remote_child, local_child, meta.size.unwrap_or(0)));
@@ -447,6 +452,20 @@ impl SftpService {
         cancel: &AtomicBool,
         on_progress: &(dyn Fn(ProgressEvent) + Send + Sync),
     ) -> Result<Option<TransferCheckpoint>, FmError> {
+        let pause = AtomicBool::new(false);
+        self.upload_with_pause(local_paths, remote_dest, op_id, cancel, &pause, on_progress)
+            .await
+    }
+
+    pub async fn upload_with_pause(
+        &self,
+        local_paths: &[String],
+        remote_dest: &str,
+        op_id: &str,
+        cancel: &AtomicBool,
+        pause: &AtomicBool,
+        on_progress: &(dyn Fn(ProgressEvent) + Send + Sync),
+    ) -> Result<Option<TransferCheckpoint>, FmError> {
         // Collect all local files
         let mut file_list: Vec<(std::path::PathBuf, String, u64)> = Vec::new();
         for local_path in local_paths {
@@ -469,10 +488,20 @@ impl SftpService {
         let files_total = file_list.len() as u32;
         let mut bytes_done: u64 = 0;
         let mut files_done: u32 = 0;
+        let mut completed_files: Vec<String> = Vec::new();
 
         for (local, remote, _size) in &file_list {
             if cancel.load(Ordering::Relaxed) {
                 return Err(FmError::Other("cancelled".into()));
+            }
+            if pause.load(Ordering::Relaxed) {
+                return Ok(Some(TransferCheckpoint {
+                    files_completed: completed_files,
+                    bytes_done,
+                    bytes_total,
+                    files_done,
+                    files_total,
+                }));
             }
 
             // Ensure remote parent directory exists
@@ -494,6 +523,7 @@ impl SftpService {
 
             bytes_done += len;
             files_done += 1;
+            completed_files.push(local.to_string_lossy().into_owned());
 
             on_progress(ProgressEvent {
                 id: op_id.to_string(),

--- a/src/lib/actions/sync.ts
+++ b/src/lib/actions/sync.ts
@@ -6,7 +6,7 @@ import { copyFiles, deleteFiles } from '$lib/services/tauri';
 import { s3Download, s3Upload, s3CopyObjects, s3DeleteObjects } from '$lib/services/s3';
 import { sftpDelete, sftpDownload, sftpUpload } from '$lib/services/sftp';
 import { error } from '$lib/services/log';
-import type { ProgressEvent, SyncEntry } from '$lib/types';
+import type { ProgressEvent, SyncEntry, TransferCheckpoint } from '$lib/types';
 
 export function executeSyncTransfer(detail: {
   entries: SyncEntry[];
@@ -32,41 +32,56 @@ export function executeSyncTransfer(detail: {
     transfersState.add(opId, 'copy', copySourcePaths, destPath);
 
     (async () => {
+      let copySucceeded = false;
       try {
         const onProgress = (e: ProgressEvent) => {
           transfersState.updateProgress(opId, e);
         };
+        let result: TransferCheckpoint | null;
 
         if (sourceBackend === 'local' && destBackend === 'local') {
-          await copyFiles(opId, copySourcePaths, destPath, onProgress);
+          result = await copyFiles(opId, copySourcePaths, destPath, onProgress);
         } else if (sourceBackend === 's3' && destBackend === 'local') {
-          await s3Download(sourceS3Id, opId, copySourcePaths, destPath, onProgress);
+          result = await s3Download(sourceS3Id, opId, copySourcePaths, destPath, onProgress);
         } else if (sourceBackend === 'local' && destBackend === 's3') {
           const prefix = s3PathToPrefix(destPath, '');
-          await s3Upload(destS3Id, opId, copySourcePaths, prefix, onProgress);
+          result = await s3Upload(destS3Id, opId, copySourcePaths, prefix, onProgress);
         } else if (sourceBackend === 's3' && destBackend === 's3') {
           const destPrefix = s3PathToPrefix(destPath, '');
-          await s3CopyObjects(sourceS3Id, opId, copySourcePaths, destS3Id, destPrefix, onProgress);
+          result = await s3CopyObjects(sourceS3Id, opId, copySourcePaths, destS3Id, destPrefix, onProgress);
         } else if (sourceBackend === 'sftp' && destBackend === 'local') {
           const sftpId = panels.active.backend === 'sftp' ? panels.active.sftpConnection?.connectionId : panels.inactive.sftpConnection?.connectionId;
-          if (sftpId) await sftpDownload(sftpId, opId, copySourcePaths, destPath, onProgress);
+          if (!sftpId) throw new Error('Missing source SFTP connection');
+          result = await sftpDownload(sftpId, opId, copySourcePaths, destPath, onProgress);
         } else if (sourceBackend === 'local' && destBackend === 'sftp') {
           const sftpId = panels.active.backend === 'sftp' ? panels.active.sftpConnection?.connectionId : panels.inactive.sftpConnection?.connectionId;
-          if (sftpId) await sftpUpload(sftpId, opId, copySourcePaths, destPath, onProgress);
+          if (!sftpId) throw new Error('Missing destination SFTP connection');
+          result = await sftpUpload(sftpId, opId, copySourcePaths, destPath, onProgress);
         } else if (sourceBackend === 'sftp' && destBackend === 'sftp') {
           const srcSftpId = panels.active.backend === 'sftp' ? panels.active.sftpConnection?.connectionId : panels.inactive.sftpConnection?.connectionId;
           const destSftpId = panels.inactive.backend === 'sftp' ? panels.inactive.sftpConnection?.connectionId : panels.active.sftpConnection?.connectionId;
-          if (srcSftpId && destSftpId) {
-            const tempDir = `/tmp/furman-sync-${opId}`;
-            await sftpDownload(srcSftpId, opId, copySourcePaths, tempDir, onProgress);
-            const downloaded = copySourcePaths.map((s) => {
-              const name = s.replace(/\/+$/, '').split('/').pop()!;
-              return `${tempDir}/${name}`;
-            });
-            await sftpUpload(destSftpId, opId + '-up', downloaded, destPath, onProgress);
+          if (!srcSftpId || !destSftpId) throw new Error('Missing SFTP connection');
+          const tempDir = `/tmp/furman-sync-${opId}`;
+          result = await sftpDownload(srcSftpId, opId, copySourcePaths, tempDir, onProgress);
+          if (result !== null) {
+            transfersState.markPaused(opId, result);
+            return;
           }
+          const downloaded = copySourcePaths.map((s) => {
+            const name = s.replace(/\/+$/, '').split('/').pop()!;
+            return `${tempDir}/${name}`;
+          });
+          result = await sftpUpload(destSftpId, opId, downloaded, destPath, onProgress);
+        } else {
+          throw new Error(`Unsupported sync: ${sourceBackend} -> ${destBackend}`);
         }
 
+        if (result !== null) {
+          transfersState.markPaused(opId, result);
+          return;
+        }
+
+        copySucceeded = true;
         transfersState.complete(opId);
         statusState.setMessage(`Synced ${toCopy.length} file(s)`);
       } catch (err: unknown) {
@@ -80,7 +95,7 @@ export function executeSyncTransfer(detail: {
           appState.showAlert('Sync failed: ' + msg);
         }
       } finally {
-        if (toDelete.length > 0) {
+        if (copySucceeded && toDelete.length > 0) {
           await executeSyncDeletes(toDelete, destBackend, destPath, destS3Id);
         }
         const reloads: Promise<void>[] = [];
@@ -116,7 +131,8 @@ export async function executeSyncDeletes(
       await s3DeleteObjects(destS3Id, 'sync-del-' + Date.now(), deletePaths);
     } else if (destBackend === 'sftp') {
       const sftpId = panels.active.backend === 'sftp' ? panels.active.sftpConnection?.connectionId : panels.inactive.sftpConnection?.connectionId;
-      if (sftpId) await sftpDelete(sftpId, deletePaths);
+      if (!sftpId) throw new Error('Missing destination SFTP connection');
+      await sftpDelete(sftpId, deletePaths);
     } else {
       await deleteFiles(deletePaths, true);
     }

--- a/src/lib/actions/viewers.ts
+++ b/src/lib/actions/viewers.ts
@@ -7,6 +7,32 @@ import { sftpDownloadTemp } from '$lib/services/sftp';
 import { error } from '$lib/services/log';
 import { promptEncryptionPassword } from './fileops';
 
+let editorOpenGeneration = 0;
+
+function showEditor(
+  filePath: string,
+  target?:
+    | { backend: 's3'; connectionId: string; path: string }
+    | { backend: 'sftp'; connectionId: string; path: string },
+) {
+  appState.editorPath = filePath;
+  appState.editorDirty = false;
+  appState.editorS3ConnectionId = '';
+  appState.editorS3Key = '';
+  appState.editorSftpConnectionId = '';
+  appState.editorSftpPath = '';
+
+  if (target?.backend === 's3') {
+    appState.editorS3ConnectionId = target.connectionId;
+    appState.editorS3Key = target.path;
+  } else if (target?.backend === 'sftp') {
+    appState.editorSftpConnectionId = target.connectionId;
+    appState.editorSftpPath = target.path;
+  }
+
+  appState.modal = 'editor';
+}
+
 // ── Extension constants ─────────────────────────────────────────────────────
 
 export const imageExtensions = new Set(['png', 'jpg', 'jpeg', 'gif', 'bmp', 'svg', 'webp', 'ico']);
@@ -131,17 +157,15 @@ export function openViewer(filePath: string, ext: string | null) {
 }
 
 export function openEditor(filePath: string) {
+  editorOpenGeneration++;
+  statusState.setMessage('');
   if (appState.externalEditor.trim()) {
     openInEditor(filePath, appState.externalEditor.trim()).catch((err) => {
       error(String(err));
     });
     return;
   }
-  appState.editorPath = filePath;
-  appState.editorDirty = false;
-  appState.editorS3ConnectionId = '';
-  appState.editorS3Key = '';
-  appState.modal = 'editor';
+  showEditor(filePath);
 }
 
 export async function openS3Viewer(s3Path: string, ext: string | null, connectionId: string, password?: string) {
@@ -230,44 +254,44 @@ export async function openSftpViewer(sftpPath: string, ext: string | null, conne
 }
 
 export async function openS3Editor(s3Path: string, connectionId: string, password?: string) {
+  const generation = ++editorOpenGeneration;
   if (!password) {
     try {
       const encrypted = await s3IsObjectEncrypted(connectionId, s3Path);
+      if (generation !== editorOpenGeneration) return;
       if (encrypted) {
         promptEncryptionPassword((pw) => {
           openS3Editor(s3Path, connectionId, pw);
         }, 'Decryption password:');
         return;
       }
-    } catch { /* continue without encryption */ }
+    } catch {
+      if (generation !== editorOpenGeneration) return;
+      // Continue without encryption when metadata detection is unavailable.
+    }
   }
 
   statusState.setMessage('Downloading for editing...');
   try {
     const localPath = await s3DownloadToTemp(connectionId, s3Path, password);
-    appState.editorPath = localPath;
-    appState.editorDirty = false;
-    appState.editorS3ConnectionId = connectionId;
-    appState.editorS3Key = s3Path;
-    appState.modal = 'editor';
+    if (generation !== editorOpenGeneration) return;
+    showEditor(localPath, { backend: 's3', connectionId, path: s3Path });
   } catch (err: unknown) {
+    if (generation !== editorOpenGeneration) return;
     error(String(err));
     appState.showAlert('Edit failed: ' + String(err));
   }
 }
 
 export async function openSftpEditor(sftpPath: string, connectionId: string) {
+  const generation = ++editorOpenGeneration;
   statusState.setMessage('Downloading for editing...');
   try {
     const localPath = await sftpDownloadTemp(connectionId, sftpPath);
-    appState.editorPath = localPath;
-    appState.editorDirty = false;
-    appState.editorS3ConnectionId = '';
-    appState.editorS3Key = '';
-    appState.editorSftpConnectionId = connectionId;
-    appState.editorSftpPath = sftpPath;
-    appState.modal = 'editor';
+    if (generation !== editorOpenGeneration) return;
+    showEditor(localPath, { backend: 'sftp', connectionId, path: sftpPath });
   } catch (err: unknown) {
+    if (generation !== editorOpenGeneration) return;
     error(String(err));
     appState.showAlert('Edit failed: ' + String(err));
   }

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -107,12 +107,22 @@
 		if (saving || !view) return;
 		saving = true;
 		const text = view.state.doc.toString();
+		const localPath = path;
+		const s3Target = appState.editorS3ConnectionId
+			? { connectionId: appState.editorS3ConnectionId, path: appState.editorS3Key }
+			: null;
+		const sftpTarget = appState.editorSftpConnectionId
+			? { connectionId: appState.editorSftpConnectionId, path: appState.editorSftpPath }
+			: null;
 		try {
-			await writeFileText(path, text);
-			if (appState.editorS3ConnectionId) {
-				await s3PutText(appState.editorS3ConnectionId, appState.editorS3Key, text);
-			} else if (appState.editorSftpConnectionId) {
-				await sftpPutText(appState.editorSftpConnectionId, appState.editorSftpPath, text);
+			if (s3Target && sftpTarget) {
+				throw new Error('Editor has multiple remote destinations');
+			}
+			await writeFileText(localPath, text);
+			if (s3Target) {
+				await s3PutText(s3Target.connectionId, s3Target.path, text);
+			} else if (sftpTarget) {
+				await sftpPutText(sftpTarget.connectionId, sftpTarget.path, text);
 			}
 			originalContent = text;
 			content = text;

--- a/src/lib/state/app.svelte.ts
+++ b/src/lib/state/app.svelte.ts
@@ -449,6 +449,13 @@ class AppState {
 
   closeModal() {
     this.modal = 'none';
+    this.editorPath = '';
+    this.editorContent = '';
+    this.editorDirty = false;
+    this.editorS3ConnectionId = '';
+    this.editorS3Key = '';
+    this.editorSftpConnectionId = '';
+    this.editorSftpPath = '';
     this.confirmMessage = '';
     this.confirmCallback = null;
     this.confirmAlertOnly = false;

--- a/src/lib/state/transfers.svelte.ts
+++ b/src/lib/state/transfers.svelte.ts
@@ -332,7 +332,7 @@ class TransfersState {
   private async dispatchCopyMove(
     t: Transfer,
     onProgress: (e: ProgressEvent) => void,
-  ): Promise<TransferCheckpoint | null | undefined> {
+  ): Promise<TransferCheckpoint | null> {
     const { srcBackend, destBackend } = t;
 
     if (t.type === 'copy') {
@@ -364,32 +364,35 @@ class TransfersState {
       if (srcBackend === 'sftp' && destBackend === 'sftp') {
         // No server-side copy in SFTP — download to temp then upload
         const tempDir = `/tmp/furman-xfer-${t.id}`;
-        await sftpDownload(t.sftpSrcConnectionId!, t.id, t.sources, tempDir, onProgress);
+        const stagingResult = await sftpDownload(t.sftpSrcConnectionId!, t.id, t.sources, tempDir, onProgress);
+        if (stagingResult !== null) return stagingResult;
         // Build list of downloaded files for upload
         const downloaded = t.sources.map((s) => {
           const name = s.replace(/\/+$/, '').split('/').pop()!;
           return `${tempDir}/${name}`;
         });
-        return await sftpUpload(t.sftpDestConnectionId!, t.id + '-up', downloaded, t.sftpDestPath!, onProgress);
+        return await sftpUpload(t.sftpDestConnectionId!, t.id, downloaded, t.sftpDestPath!, onProgress);
       }
       // Cross-protocol: S3 ↔ SFTP (via temp dir)
       if (srcBackend === 's3' && destBackend === 'sftp') {
         const tempDir = `/tmp/furman-xfer-${t.id}`;
-        await s3Download(t.s3SrcConnectionId!, t.id, t.sources, tempDir, onProgress, t.encryptionPassword);
+        const stagingResult = await s3Download(t.s3SrcConnectionId!, t.id, t.sources, tempDir, onProgress, t.encryptionPassword);
+        if (stagingResult !== null) return stagingResult;
         const downloaded = t.sources.map((s) => {
           const name = s.replace(/\/+$/, '').split('/').pop()!;
           return `${tempDir}/${name}`;
         });
-        return await sftpUpload(t.sftpDestConnectionId!, t.id + '-up', downloaded, t.sftpDestPath!, onProgress);
+        return await sftpUpload(t.sftpDestConnectionId!, t.id, downloaded, t.sftpDestPath!, onProgress);
       }
       if (srcBackend === 'sftp' && destBackend === 's3') {
         const tempDir = `/tmp/furman-xfer-${t.id}`;
-        await sftpDownload(t.sftpSrcConnectionId!, t.id, t.sources, tempDir, onProgress);
+        const stagingResult = await sftpDownload(t.sftpSrcConnectionId!, t.id, t.sources, tempDir, onProgress);
+        if (stagingResult !== null) return stagingResult;
         const downloaded = t.sources.map((s) => {
           const name = s.replace(/\/+$/, '').split('/').pop()!;
           return `${tempDir}/${name}`;
         });
-        return await s3Upload(t.s3DestConnectionId!, t.id + '-up', downloaded, t.s3DestPrefix!, onProgress);
+        return await s3Upload(t.s3DestConnectionId!, t.id, downloaded, t.s3DestPrefix!, onProgress);
       }
     }
 
@@ -400,8 +403,9 @@ class TransfersState {
       // S3 move = copy/download + delete source
       if (srcBackend === 's3' && destBackend === 'local') {
         const result = await s3Download(t.s3SrcConnectionId!, t.id, t.sources, t.destination, onProgress, t.encryptionPassword);
+        if (result !== null) return result;
         await s3DeleteObjects(t.s3SrcConnectionId!, t.id + '-del', t.sources);
-        return result;
+        return null;
       }
       if (srcBackend === 'local' && destBackend === 's3') {
         let result;
@@ -410,65 +414,75 @@ class TransfersState {
         } else {
           result = await s3Upload(t.s3DestConnectionId!, t.id, t.sources, t.s3DestPrefix!, onProgress);
         }
+        if (result !== null) return result;
         await deleteFiles(t.sources, true);
-        return result;
+        return null;
       }
       if (srcBackend === 's3' && destBackend === 's3') {
         const result = await s3CopyObjects(
           t.s3SrcConnectionId!, t.id, t.sources,
           t.s3DestConnectionId!, t.s3DestPrefix!, onProgress,
         );
+        if (result !== null) return result;
         await s3DeleteObjects(t.s3SrcConnectionId!, t.id + '-del', t.sources);
-        return result;
+        return null;
       }
       // SFTP move = download/upload + delete source
       if (srcBackend === 'sftp' && destBackend === 'local') {
         const result = await sftpDownload(t.sftpSrcConnectionId!, t.id, t.sources, t.destination, onProgress);
+        if (result !== null) return result;
         await sftpDelete(t.sftpSrcConnectionId!, t.sources);
-        return result;
+        return null;
       }
       if (srcBackend === 'local' && destBackend === 'sftp') {
         const result = await sftpUpload(t.sftpDestConnectionId!, t.id, t.sources, t.sftpDestPath!, onProgress);
+        if (result !== null) return result;
         await deleteFiles(t.sources, true);
-        return result;
+        return null;
       }
       if (srcBackend === 'sftp' && destBackend === 'sftp') {
         const tempDir = `/tmp/furman-xfer-${t.id}`;
-        await sftpDownload(t.sftpSrcConnectionId!, t.id, t.sources, tempDir, onProgress);
+        const stagingResult = await sftpDownload(t.sftpSrcConnectionId!, t.id, t.sources, tempDir, onProgress);
+        if (stagingResult !== null) return stagingResult;
         const downloaded = t.sources.map((s) => {
           const name = s.replace(/\/+$/, '').split('/').pop()!;
           return `${tempDir}/${name}`;
         });
-        const result = await sftpUpload(t.sftpDestConnectionId!, t.id + '-up', downloaded, t.sftpDestPath!, onProgress);
+        const result = await sftpUpload(t.sftpDestConnectionId!, t.id, downloaded, t.sftpDestPath!, onProgress);
+        if (result !== null) return result;
         await sftpDelete(t.sftpSrcConnectionId!, t.sources);
-        return result;
+        return null;
       }
       // Cross-protocol: S3 ↔ SFTP (via temp dir)
       if (srcBackend === 's3' && destBackend === 'sftp') {
         const tempDir = `/tmp/furman-xfer-${t.id}`;
-        await s3Download(t.s3SrcConnectionId!, t.id, t.sources, tempDir, onProgress, t.encryptionPassword);
+        const stagingResult = await s3Download(t.s3SrcConnectionId!, t.id, t.sources, tempDir, onProgress, t.encryptionPassword);
+        if (stagingResult !== null) return stagingResult;
         const downloaded = t.sources.map((s) => {
           const name = s.replace(/\/+$/, '').split('/').pop()!;
           return `${tempDir}/${name}`;
         });
-        const result = await sftpUpload(t.sftpDestConnectionId!, t.id + '-up', downloaded, t.sftpDestPath!, onProgress);
+        const result = await sftpUpload(t.sftpDestConnectionId!, t.id, downloaded, t.sftpDestPath!, onProgress);
+        if (result !== null) return result;
         await s3DeleteObjects(t.s3SrcConnectionId!, t.id + '-del', t.sources);
-        return result;
+        return null;
       }
       if (srcBackend === 'sftp' && destBackend === 's3') {
         const tempDir = `/tmp/furman-xfer-${t.id}`;
-        await sftpDownload(t.sftpSrcConnectionId!, t.id, t.sources, tempDir, onProgress);
+        const stagingResult = await sftpDownload(t.sftpSrcConnectionId!, t.id, t.sources, tempDir, onProgress);
+        if (stagingResult !== null) return stagingResult;
         const downloaded = t.sources.map((s) => {
           const name = s.replace(/\/+$/, '').split('/').pop()!;
           return `${tempDir}/${name}`;
         });
-        const result = await s3Upload(t.s3DestConnectionId!, t.id + '-up', downloaded, t.s3DestPrefix!, onProgress);
+        const result = await s3Upload(t.s3DestConnectionId!, t.id, downloaded, t.s3DestPrefix!, onProgress);
+        if (result !== null) return result;
         await sftpDelete(t.sftpSrcConnectionId!, t.sources);
-        return result;
+        return null;
       }
     }
 
-    return null;
+    throw new Error(`Unsupported transfer: ${t.type} ${srcBackend} -> ${destBackend}`);
   }
 }
 


### PR DESCRIPTION
## Summary

- verify SFTP server keys against `~/.ssh/known_hosts` and document host enrollment
- prevent move and sync deletions until every destination stage completes successfully
- isolate local, S3, and SFTP editor destinations and reject stale asynchronous opens
- honor SFTP pause checkpoints and fail instead of silently skipping unreadable transfer sources

## Validation

- `npm run check`
- `npm run lint`
- `npm run build`
- `cargo check --locked --lib`
- `cargo test --locked --lib` (14 passed)
- `cargo test --locked --no-run`
- `cargo check --locked --features mcp --bin furman-mcp`
- `git diff --check`

## Notes

- SFTP hosts must now have a verified entry in `~/.ssh/known_hosts`; unknown and changed keys fail closed.
- Repository-wide `cargo fmt --check` still reports pre-existing formatting differences in unrelated Rust files, so this PR does not bulk-format them.