### PR TITLE
Implement resumable file transfers

### DIFF
--- a/docs/s3.md
+++ b/docs/s3.md
@@ -66,7 +66,7 @@ Press **Cmd+Y** to sync between panels. The sync dialog shows a diff view of all
 
 - **Comparison modes** — size/modification time (fast) or ETag/checksum (accurate)
 - **Exclude patterns** — comma-separated glob patterns to skip files (default: `.DS_Store, Thumbs.db, .git/**`), persisted across sessions
-- **Bidirectional** — sync in either direction between local ↔ S3, S3 ↔ S3, local ↔ SFTP, or SFTP ↔ SFTP
+- **Bidirectional** — sync in either direction between local and S3 panels, including S3 ↔ S3
 
 ## Object Operations
 

--- a/docs/sftp.md
+++ b/docs/sftp.md
@@ -47,7 +47,7 @@ Replace `22` with the configured SSH port. Do not add a key until its displayed 
 
 ## Sync
 
-Press **Cmd+Y** to sync between an SFTP panel and a local or SFTP panel. Supports the same diff view, exclude patterns, and selective transfer as S3 sync.
+Directory comparison and sync are not currently available for SFTP panels. Copy and move operations remain available between SFTP, local, and S3 panels.
 
 ## Bookmarks
 

--- a/src-tauri/src/commands/file.rs
+++ b/src-tauri/src/commands/file.rs
@@ -19,6 +19,7 @@ pub fn copy_files(
     id: String,
     sources: Vec<String>,
     destination: String,
+    checkpoint: Option<TransferCheckpoint>,
     channel: Channel<ProgressEvent>,
     state: tauri::State<'_, FileOpState>,
 ) -> Result<Option<TransferCheckpoint>, FmError> {
@@ -31,9 +32,16 @@ pub fn copy_files(
         map.insert(id.clone(), flags.clone());
     }
 
-    let result = local::copy_files_core(&id, &sources, &destination, &flags, &|event| {
-        let _ = channel.send(event);
-    });
+    let result = local::copy_files_core_with_checkpoint(
+        &id,
+        &sources,
+        &destination,
+        &flags,
+        &|event| {
+            let _ = channel.send(event);
+        },
+        checkpoint.as_ref(),
+    );
 
     // Clean up the flags from state.
     if let Ok(mut map) = state.0.lock() {
@@ -53,6 +61,7 @@ pub fn move_files(
     id: String,
     sources: Vec<String>,
     destination: String,
+    checkpoint: Option<TransferCheckpoint>,
     channel: Channel<ProgressEvent>,
     state: tauri::State<'_, FileOpState>,
 ) -> Result<Option<TransferCheckpoint>, FmError> {
@@ -65,9 +74,16 @@ pub fn move_files(
         map.insert(id.clone(), flags.clone());
     }
 
-    let result = local::move_files_core(&id, &sources, &destination, &flags, &|event| {
-        let _ = channel.send(event);
-    });
+    let result = local::move_files_core_with_checkpoint(
+        &id,
+        &sources,
+        &destination,
+        &flags,
+        &|event| {
+            let _ = channel.send(event);
+        },
+        checkpoint.as_ref(),
+    );
 
     // Clean up the flags from state.
     if let Ok(mut map) = state.0.lock() {

--- a/src-tauri/src/commands/s3.rs
+++ b/src-tauri/src/commands/s3.rs
@@ -167,6 +167,7 @@ pub async fn s3_download(
     keys: Vec<String>,
     destination: String,
     password: Option<String>,
+    checkpoint: Option<TransferCheckpoint>,
     channel: Channel<ProgressEvent>,
 ) -> Result<Option<TransferCheckpoint>, FmError> {
     let service = get_service(&state, &id)?;
@@ -184,7 +185,7 @@ pub async fn s3_download(
     }
 
     let result = service
-        .download(
+        .download_with_checkpoint(
             &keys,
             &destination,
             &op_id,
@@ -194,6 +195,7 @@ pub async fn s3_download(
                 let _ = channel.send(evt);
             },
             password.as_deref(),
+            checkpoint.as_ref(),
         )
         .await;
 
@@ -212,6 +214,7 @@ pub async fn s3_upload(
     op_id: String,
     sources: Vec<String>,
     dest_prefix: String,
+    checkpoint: Option<TransferCheckpoint>,
     channel: Channel<ProgressEvent>,
 ) -> Result<Option<TransferCheckpoint>, FmError> {
     let service = get_service(&state, &id)?;
@@ -229,7 +232,7 @@ pub async fn s3_upload(
     }
 
     let result = service
-        .upload(
+        .upload_with_checkpoint(
             &sources,
             &dest_prefix,
             &op_id,
@@ -239,6 +242,7 @@ pub async fn s3_upload(
                 let _ = channel.send(evt);
             },
             None,
+            checkpoint.as_ref(),
         )
         .await;
 
@@ -259,6 +263,7 @@ pub async fn s3_upload_encrypted(
     dest_prefix: String,
     password: String,
     encryption_config: Option<crate::s3::crypto::EncryptionConfig>,
+    checkpoint: Option<TransferCheckpoint>,
     channel: Channel<ProgressEvent>,
 ) -> Result<Option<TransferCheckpoint>, FmError> {
     let service = get_service(&state, &id)?;
@@ -277,7 +282,7 @@ pub async fn s3_upload_encrypted(
     }
 
     let result = service
-        .upload_encrypted(
+        .upload_encrypted_with_checkpoint(
             &sources,
             &dest_prefix,
             &password,
@@ -288,6 +293,7 @@ pub async fn s3_upload_encrypted(
             &|evt| {
                 let _ = channel.send(evt);
             },
+            checkpoint.as_ref(),
         )
         .await;
 
@@ -307,6 +313,7 @@ pub async fn s3_copy_objects(
     src_keys: Vec<String>,
     dest_id: String,
     dest_prefix: String,
+    checkpoint: Option<TransferCheckpoint>,
     channel: Channel<ProgressEvent>,
 ) -> Result<Option<TransferCheckpoint>, FmError> {
     let (src_client, src_bucket, dest_client, dest_bucket) = {
@@ -341,7 +348,7 @@ pub async fn s3_copy_objects(
     let service = S3Service::new(src_client.clone(), src_bucket.clone());
 
     let result = service
-        .copy_objects(
+        .copy_objects_with_checkpoint(
             &src_client,
             &src_bucket,
             &src_keys,
@@ -354,6 +361,7 @@ pub async fn s3_copy_objects(
             &|evt| {
                 let _ = channel.send(evt);
             },
+            checkpoint.as_ref(),
         )
         .await;
 

--- a/src-tauri/src/commands/sftp.rs
+++ b/src-tauri/src/commands/sftp.rs
@@ -188,6 +188,7 @@ pub async fn sftp_download(
     op_id: String,
     keys: Vec<String>,
     destination: String,
+    checkpoint: Option<TransferCheckpoint>,
     channel: Channel<ProgressEvent>,
 ) -> Result<Option<TransferCheckpoint>, FmError> {
     let flags = {
@@ -207,7 +208,7 @@ pub async fn sftp_download(
         .collect();
 
     let result = svc
-        .download_with_pause(
+        .download_with_checkpoint(
             &remote_paths,
             &destination,
             &op_id,
@@ -216,6 +217,7 @@ pub async fn sftp_download(
             &|evt| {
                 let _ = channel.send(evt);
             },
+            checkpoint.as_ref(),
         )
         .await;
 
@@ -237,6 +239,7 @@ pub async fn sftp_upload(
     op_id: String,
     sources: Vec<String>,
     remote_prefix: String,
+    checkpoint: Option<TransferCheckpoint>,
     channel: Channel<ProgressEvent>,
 ) -> Result<Option<TransferCheckpoint>, FmError> {
     let flags = {
@@ -253,7 +256,7 @@ pub async fn sftp_upload(
     let remote_dest = strip_sftp_prefix(&remote_prefix);
 
     let result = svc
-        .upload_with_pause(
+        .upload_with_checkpoint(
             &sources,
             remote_dest,
             &op_id,
@@ -262,6 +265,7 @@ pub async fn sftp_upload(
             &|evt| {
                 let _ = channel.send(evt);
             },
+            checkpoint.as_ref(),
         )
         .await;
 

--- a/src-tauri/src/local.rs
+++ b/src-tauri/src/local.rs
@@ -5,6 +5,7 @@
 //! without needing a Tauri runtime.
 
 use crate::models::{FmError, ProgressEvent, TransferCheckpoint};
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -82,6 +83,37 @@ pub fn copy_recursive(
     completed_files: &mut Vec<String>,
     last_progress: &mut Instant,
 ) -> Result<CopyResult, FmError> {
+    let mut completed = completed_files.iter().cloned().collect();
+    copy_recursive_with_completed(
+        src,
+        dst,
+        id,
+        bytes_done,
+        bytes_total,
+        files_done,
+        files_total,
+        on_progress,
+        flags,
+        completed_files,
+        &mut completed,
+        last_progress,
+    )
+}
+
+fn copy_recursive_with_completed(
+    src: &Path,
+    dst: &Path,
+    id: &str,
+    bytes_done: &mut u64,
+    bytes_total: u64,
+    files_done: &mut u32,
+    files_total: u32,
+    on_progress: &dyn Fn(ProgressEvent),
+    flags: &OpFlags,
+    completed_files: &mut Vec<String>,
+    completed: &mut HashSet<String>,
+    last_progress: &mut Instant,
+) -> Result<CopyResult, FmError> {
     if flags.cancel.load(Ordering::Relaxed) {
         return Err(FmError::Other("Operation cancelled".into()));
     }
@@ -100,7 +132,7 @@ pub fn copy_recursive(
             let entry = entry?;
             let child_src = entry.path();
             let child_dst = dst.join(entry.file_name());
-            match copy_recursive(
+            match copy_recursive_with_completed(
                 &child_src,
                 &child_dst,
                 id,
@@ -111,6 +143,7 @@ pub fn copy_recursive(
                 on_progress,
                 flags,
                 completed_files,
+                completed,
                 last_progress,
             )? {
                 CopyResult::Done => {}
@@ -118,6 +151,11 @@ pub fn copy_recursive(
             }
         }
     } else {
+        let identity = src.to_string_lossy().into_owned();
+        if completed.contains(&identity) {
+            return Ok(CopyResult::Done);
+        }
+
         // Ensure parent directory exists.
         if let Some(parent) = dst.parent() {
             fs::create_dir_all(parent)?;
@@ -127,7 +165,8 @@ pub fn copy_recursive(
         fs::copy(src, dst)?;
         *bytes_done += size;
         *files_done += 1;
-        completed_files.push(src.to_string_lossy().into_owned());
+        completed_files.push(identity.clone());
+        completed.insert(identity);
 
         // Throttle progress events; always emit first and final
         let now = Instant::now();
@@ -160,6 +199,17 @@ pub fn copy_files_core(
     flags: &OpFlags,
     on_progress: &dyn Fn(ProgressEvent),
 ) -> Result<Option<TransferCheckpoint>, FmError> {
+    copy_files_core_with_checkpoint(id, sources, destination, flags, on_progress, None)
+}
+
+pub fn copy_files_core_with_checkpoint(
+    id: &str,
+    sources: &[String],
+    destination: &str,
+    flags: &OpFlags,
+    on_progress: &dyn Fn(ProgressEvent),
+    checkpoint: Option<&TransferCheckpoint>,
+) -> Result<Option<TransferCheckpoint>, FmError> {
     let dest = PathBuf::from(destination);
 
     // Pre-calculate totals for progress.
@@ -171,9 +221,14 @@ pub fn copy_files_core(
         files_total += count_files(&p);
     }
 
-    let mut bytes_done: u64 = 0;
-    let mut files_done: u32 = 0;
-    let mut completed_files: Vec<String> = Vec::new();
+    let mut bytes_done = checkpoint.map_or(0, |c| c.bytes_done);
+    let mut files_done = checkpoint.map_or(0, |c| c.files_done);
+    let mut completed_files = checkpoint.map_or_else(Vec::new, |c| c.files_completed.clone());
+    let mut completed: HashSet<String> = completed_files.iter().cloned().collect();
+    if let Some(c) = checkpoint {
+        bytes_total = c.bytes_total;
+        files_total = c.files_total;
+    }
     let mut last_progress = Instant::now();
 
     for src in sources {
@@ -183,7 +238,7 @@ pub fn copy_files_core(
             .ok_or_else(|| FmError::Other(format!("invalid source path: {src}")))?;
         let dst_path = dest.join(file_name);
 
-        match copy_recursive(
+        match copy_recursive_with_completed(
             &src_path,
             &dst_path,
             id,
@@ -194,6 +249,7 @@ pub fn copy_files_core(
             on_progress,
             flags,
             &mut completed_files,
+            &mut completed,
             &mut last_progress,
         )? {
             CopyResult::Done => {}
@@ -207,6 +263,19 @@ pub fn copy_files_core(
                 }));
             }
         }
+    }
+
+    if flags.cancel.load(Ordering::Relaxed) {
+        return Err(FmError::Other("Operation cancelled".into()));
+    }
+    if flags.pause.load(Ordering::Relaxed) {
+        return Ok(Some(TransferCheckpoint {
+            files_completed: completed_files,
+            bytes_done,
+            bytes_total,
+            files_done,
+            files_total,
+        }));
     }
     Ok(None)
 }
@@ -223,6 +292,17 @@ pub fn move_files_core(
     flags: &OpFlags,
     on_progress: &dyn Fn(ProgressEvent),
 ) -> Result<Option<TransferCheckpoint>, FmError> {
+    move_files_core_with_checkpoint(id, sources, destination, flags, on_progress, None)
+}
+
+pub fn move_files_core_with_checkpoint(
+    id: &str,
+    sources: &[String],
+    destination: &str,
+    flags: &OpFlags,
+    on_progress: &dyn Fn(ProgressEvent),
+    checkpoint: Option<&TransferCheckpoint>,
+) -> Result<Option<TransferCheckpoint>, FmError> {
     let dest = PathBuf::from(destination);
 
     // Pre-calculate totals.
@@ -234,9 +314,14 @@ pub fn move_files_core(
         files_total += count_files(&p);
     }
 
-    let mut bytes_done: u64 = 0;
-    let mut files_done: u32 = 0;
-    let mut completed_files: Vec<String> = Vec::new();
+    let mut bytes_done = checkpoint.map_or(0, |c| c.bytes_done);
+    let mut files_done = checkpoint.map_or(0, |c| c.files_done);
+    let mut completed_files = checkpoint.map_or_else(Vec::new, |c| c.files_completed.clone());
+    let mut completed: HashSet<String> = completed_files.iter().cloned().collect();
+    if let Some(c) = checkpoint {
+        bytes_total = c.bytes_total;
+        files_total = c.files_total;
+    }
     let mut last_progress = Instant::now();
 
     for src in sources {
@@ -252,6 +337,9 @@ pub fn move_files_core(
                 files_total,
             }));
         }
+        if completed.contains(src) {
+            continue;
+        }
 
         let src_path = PathBuf::from(src);
         let file_name = src_path
@@ -266,6 +354,7 @@ pub fn move_files_core(
             bytes_done += size;
             files_done += count;
             completed_files.push(src.clone());
+            completed.insert(src.clone());
 
             on_progress(ProgressEvent {
                 id: id.to_string(),
@@ -277,7 +366,7 @@ pub fn move_files_core(
             });
         } else {
             // Cross-device: copy then delete source.
-            match copy_recursive(
+            match copy_recursive_with_completed(
                 &src_path,
                 &dst_path,
                 id,
@@ -288,13 +377,29 @@ pub fn move_files_core(
                 on_progress,
                 flags,
                 &mut completed_files,
+                &mut completed,
                 &mut last_progress,
             )? {
                 CopyResult::Done => {
+                    if flags.cancel.load(Ordering::Relaxed) {
+                        return Err(FmError::Other("Operation cancelled".into()));
+                    }
+                    if flags.pause.load(Ordering::Relaxed) {
+                        return Ok(Some(TransferCheckpoint {
+                            files_completed: completed_files,
+                            bytes_done,
+                            bytes_total,
+                            files_done,
+                            files_total,
+                        }));
+                    }
                     if src_path.is_dir() {
                         fs::remove_dir_all(&src_path)?;
                     } else {
                         fs::remove_file(&src_path)?;
+                    }
+                    if completed.insert(src.clone()) {
+                        completed_files.push(src.clone());
                     }
                 }
                 CopyResult::Paused => {
@@ -308,6 +413,19 @@ pub fn move_files_core(
                 }
             }
         }
+    }
+
+    if flags.cancel.load(Ordering::Relaxed) {
+        return Err(FmError::Other("Operation cancelled".into()));
+    }
+    if flags.pause.load(Ordering::Relaxed) {
+        return Ok(Some(TransferCheckpoint {
+            files_completed: completed_files,
+            bytes_done,
+            bytes_total,
+            files_done,
+            files_total,
+        }));
     }
     Ok(None)
 }

--- a/src-tauri/src/s3/service.rs
+++ b/src-tauri/src/s3/service.rs
@@ -1,7 +1,7 @@
 use aws_config::BehaviorVersion;
 use aws_credential_types::provider::ProvideCredentials;
 use aws_sdk_s3::Client as S3Client;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
@@ -266,6 +266,30 @@ impl S3Service {
         on_progress: &(dyn Fn(ProgressEvent) + Send + Sync),
         password: Option<&str>,
     ) -> Result<Option<TransferCheckpoint>, FmError> {
+        self.download_with_checkpoint(
+            keys,
+            destination,
+            op_id,
+            cancel,
+            pause,
+            on_progress,
+            password,
+            None,
+        )
+        .await
+    }
+
+    pub async fn download_with_checkpoint(
+        &self,
+        keys: &[String],
+        destination: &str,
+        op_id: &str,
+        cancel: &AtomicBool,
+        pause: &AtomicBool,
+        on_progress: &(dyn Fn(ProgressEvent) + Send + Sync),
+        password: Option<&str>,
+        checkpoint: Option<&TransferCheckpoint>,
+    ) -> Result<Option<TransferCheckpoint>, FmError> {
         let dest = PathBuf::from(destination);
 
         // Resolve actual keys: for prefix keys (dirs), list all children
@@ -291,11 +315,16 @@ impl S3Service {
             }
         }
 
-        let files_total = resolved.len() as u32;
-        let bytes_total: u64 = resolved.iter().map(|(_, s)| *s).sum();
-        let mut bytes_done: u64 = 0;
-        let mut files_done: u32 = 0;
-        let mut completed_files: Vec<String> = Vec::new();
+        let mut files_total = resolved.len() as u32;
+        let mut bytes_total: u64 = resolved.iter().map(|(_, s)| *s).sum();
+        let mut bytes_done = checkpoint.map_or(0, |c| c.bytes_done);
+        let mut files_done = checkpoint.map_or(0, |c| c.files_done);
+        let mut completed_files = checkpoint.map_or_else(Vec::new, |c| c.files_completed.clone());
+        let completed: HashSet<String> = completed_files.iter().cloned().collect();
+        if let Some(c) = checkpoint {
+            bytes_total = c.bytes_total;
+            files_total = c.files_total;
+        }
 
         for (key, _size) in &resolved {
             if cancel.load(Ordering::Relaxed) {
@@ -309,6 +338,9 @@ impl S3Service {
                     files_done,
                     files_total,
                 }));
+            }
+            if completed.contains(key) {
+                continue;
             }
 
             let filename = key.rsplit('/').next().unwrap_or(key);
@@ -450,6 +482,18 @@ impl S3Service {
             });
         }
 
+        if cancel.load(Ordering::Relaxed) {
+            return Err(FmError::Other("Operation cancelled".into()));
+        }
+        if pause.load(Ordering::Relaxed) {
+            return Ok(Some(TransferCheckpoint {
+                files_completed: completed_files,
+                bytes_done,
+                bytes_total,
+                files_done,
+                files_total,
+            }));
+        }
         Ok(None)
     }
 
@@ -464,6 +508,30 @@ impl S3Service {
         pause: &AtomicBool,
         on_progress: &(dyn Fn(ProgressEvent) + Send + Sync),
         metadata: Option<&HashMap<String, String>>,
+    ) -> Result<Option<TransferCheckpoint>, FmError> {
+        self.upload_with_checkpoint(
+            sources,
+            dest_prefix,
+            op_id,
+            cancel,
+            pause,
+            on_progress,
+            metadata,
+            None,
+        )
+        .await
+    }
+
+    pub async fn upload_with_checkpoint(
+        &self,
+        sources: &[String],
+        dest_prefix: &str,
+        op_id: &str,
+        cancel: &AtomicBool,
+        pause: &AtomicBool,
+        on_progress: &(dyn Fn(ProgressEvent) + Send + Sync),
+        metadata: Option<&HashMap<String, String>>,
+        checkpoint: Option<&TransferCheckpoint>,
     ) -> Result<Option<TransferCheckpoint>, FmError> {
         // Collect all files to upload (expand directories)
         let mut file_list: Vec<(PathBuf, String)> = Vec::new();
@@ -486,14 +554,19 @@ impl S3Service {
             }
         }
 
-        let files_total = file_list.len() as u32;
-        let bytes_total: u64 = file_list
+        let mut files_total = file_list.len() as u32;
+        let mut bytes_total: u64 = file_list
             .iter()
             .map(|(p, _)| std::fs::metadata(p).map(|m| m.len()).unwrap_or(0))
             .sum();
-        let mut bytes_done: u64 = 0;
-        let mut files_done: u32 = 0;
-        let mut completed_files: Vec<String> = Vec::new();
+        let mut bytes_done = checkpoint.map_or(0, |c| c.bytes_done);
+        let mut files_done = checkpoint.map_or(0, |c| c.files_done);
+        let mut completed_files = checkpoint.map_or_else(Vec::new, |c| c.files_completed.clone());
+        let completed: HashSet<String> = completed_files.iter().cloned().collect();
+        if let Some(c) = checkpoint {
+            bytes_total = c.bytes_total;
+            files_total = c.files_total;
+        }
 
         for (local_path, key) in &file_list {
             if cancel.load(Ordering::Relaxed) {
@@ -507,6 +580,10 @@ impl S3Service {
                     files_done,
                     files_total,
                 }));
+            }
+            let identity = local_path.to_string_lossy().into_owned();
+            if completed.contains(&identity) {
+                continue;
             }
 
             let file_size = std::fs::metadata(local_path).map(|m| m.len()).unwrap_or(0);
@@ -570,7 +647,7 @@ impl S3Service {
             }
 
             files_done += 1;
-            completed_files.push(key.clone());
+            completed_files.push(identity);
 
             on_progress(ProgressEvent {
                 id: op_id.to_string(),
@@ -582,6 +659,18 @@ impl S3Service {
             });
         }
 
+        if cancel.load(Ordering::Relaxed) {
+            return Err(FmError::Other("Operation cancelled".into()));
+        }
+        if pause.load(Ordering::Relaxed) {
+            return Ok(Some(TransferCheckpoint {
+                files_completed: completed_files,
+                bytes_done,
+                bytes_total,
+                files_done,
+                files_total,
+            }));
+        }
         Ok(None)
     }
 
@@ -596,6 +685,32 @@ impl S3Service {
         cancel: &AtomicBool,
         pause: &AtomicBool,
         on_progress: &(dyn Fn(ProgressEvent) + Send + Sync),
+    ) -> Result<Option<TransferCheckpoint>, FmError> {
+        self.upload_encrypted_with_checkpoint(
+            sources,
+            dest_prefix,
+            password,
+            config,
+            op_id,
+            cancel,
+            pause,
+            on_progress,
+            None,
+        )
+        .await
+    }
+
+    pub async fn upload_encrypted_with_checkpoint(
+        &self,
+        sources: &[String],
+        dest_prefix: &str,
+        password: &str,
+        config: &EncryptionConfig,
+        op_id: &str,
+        cancel: &AtomicBool,
+        pause: &AtomicBool,
+        on_progress: &(dyn Fn(ProgressEvent) + Send + Sync),
+        checkpoint: Option<&TransferCheckpoint>,
     ) -> Result<Option<TransferCheckpoint>, FmError> {
         use super::crypto;
 
@@ -619,14 +734,19 @@ impl S3Service {
             }
         }
 
-        let files_total = file_list.len() as u32;
-        let bytes_total: u64 = file_list
+        let mut files_total = file_list.len() as u32;
+        let mut bytes_total: u64 = file_list
             .iter()
             .map(|(p, _)| std::fs::metadata(p).map(|m| m.len()).unwrap_or(0))
             .sum();
-        let mut bytes_done: u64 = 0;
-        let mut files_done: u32 = 0;
-        let mut completed_files: Vec<String> = Vec::new();
+        let mut bytes_done = checkpoint.map_or(0, |c| c.bytes_done);
+        let mut files_done = checkpoint.map_or(0, |c| c.files_done);
+        let mut completed_files = checkpoint.map_or_else(Vec::new, |c| c.files_completed.clone());
+        let completed: HashSet<String> = completed_files.iter().cloned().collect();
+        if let Some(c) = checkpoint {
+            bytes_total = c.bytes_total;
+            files_total = c.files_total;
+        }
         let mut temp_files: Vec<PathBuf> = Vec::new();
 
         for (local_path, key) in &file_list {
@@ -643,6 +763,10 @@ impl S3Service {
                     files_done,
                     files_total,
                 }));
+            }
+            let identity = local_path.to_string_lossy().into_owned();
+            if completed.contains(&identity) {
+                continue;
             }
 
             let filename = local_path
@@ -736,7 +860,7 @@ impl S3Service {
             }
 
             files_done += 1;
-            completed_files.push(key.clone());
+            completed_files.push(identity);
             on_progress(ProgressEvent {
                 id: op_id.to_string(),
                 bytes_done,
@@ -748,6 +872,18 @@ impl S3Service {
         }
 
         crypto::cleanup_temp_files(&temp_files, config.secure_temp_cleanup);
+        if cancel.load(Ordering::Relaxed) {
+            return Err(FmError::Other("Operation cancelled".into()));
+        }
+        if pause.load(Ordering::Relaxed) {
+            return Ok(Some(TransferCheckpoint {
+                files_completed: completed_files,
+                bytes_done,
+                bytes_total,
+                files_done,
+                files_total,
+            }));
+        }
         Ok(None)
     }
 
@@ -782,6 +918,36 @@ impl S3Service {
         pause: &AtomicBool,
         on_progress: &(dyn Fn(ProgressEvent) + Send + Sync),
     ) -> Result<Option<TransferCheckpoint>, FmError> {
+        self.copy_objects_with_checkpoint(
+            src_client,
+            src_bucket,
+            src_keys,
+            dest_client,
+            dest_bucket,
+            dest_prefix,
+            op_id,
+            cancel,
+            pause,
+            on_progress,
+            None,
+        )
+        .await
+    }
+
+    pub async fn copy_objects_with_checkpoint(
+        &self,
+        src_client: &S3Client,
+        src_bucket: &str,
+        src_keys: &[String],
+        dest_client: &S3Client,
+        dest_bucket: &str,
+        dest_prefix: &str,
+        op_id: &str,
+        cancel: &AtomicBool,
+        pause: &AtomicBool,
+        on_progress: &(dyn Fn(ProgressEvent) + Send + Sync),
+        checkpoint: Option<&TransferCheckpoint>,
+    ) -> Result<Option<TransferCheckpoint>, FmError> {
         let mut resolved: Vec<(String, u64)> = Vec::new();
         for raw_key in src_keys {
             let key = strip_s3_prefix(raw_key, src_bucket);
@@ -803,11 +969,16 @@ impl S3Service {
             }
         }
 
-        let files_total = resolved.len() as u32;
-        let bytes_total: u64 = resolved.iter().map(|(_, s)| *s).sum();
-        let mut bytes_done: u64 = 0;
-        let mut files_done: u32 = 0;
-        let mut completed_files: Vec<String> = Vec::new();
+        let mut files_total = resolved.len() as u32;
+        let mut bytes_total: u64 = resolved.iter().map(|(_, s)| *s).sum();
+        let mut bytes_done = checkpoint.map_or(0, |c| c.bytes_done);
+        let mut files_done = checkpoint.map_or(0, |c| c.files_done);
+        let mut completed_files = checkpoint.map_or_else(Vec::new, |c| c.files_completed.clone());
+        let completed: HashSet<String> = completed_files.iter().cloned().collect();
+        if let Some(c) = checkpoint {
+            bytes_total = c.bytes_total;
+            files_total = c.files_total;
+        }
 
         for (key, size) in &resolved {
             if cancel.load(Ordering::Relaxed) {
@@ -821,6 +992,9 @@ impl S3Service {
                     files_done,
                     files_total,
                 }));
+            }
+            if completed.contains(key) {
+                continue;
             }
 
             let filename = key.rsplit('/').next().unwrap_or(key);
@@ -851,6 +1025,18 @@ impl S3Service {
             });
         }
 
+        if cancel.load(Ordering::Relaxed) {
+            return Err(FmError::Other("Operation cancelled".into()));
+        }
+        if pause.load(Ordering::Relaxed) {
+            return Ok(Some(TransferCheckpoint {
+                files_completed: completed_files,
+                bytes_done,
+                bytes_total,
+                files_done,
+                files_total,
+            }));
+        }
         Ok(None)
     }
 

--- a/src-tauri/src/sftp/service.rs
+++ b/src-tauri/src/sftp/service.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -233,6 +234,28 @@ impl SftpService {
         pause: &AtomicBool,
         on_progress: &(dyn Fn(ProgressEvent) + Send + Sync),
     ) -> Result<Option<TransferCheckpoint>, FmError> {
+        self.download_with_checkpoint(
+            remote_paths,
+            local_dest,
+            op_id,
+            cancel,
+            pause,
+            on_progress,
+            None,
+        )
+        .await
+    }
+
+    pub async fn download_with_checkpoint(
+        &self,
+        remote_paths: &[String],
+        local_dest: &str,
+        op_id: &str,
+        cancel: &AtomicBool,
+        pause: &AtomicBool,
+        on_progress: &(dyn Fn(ProgressEvent) + Send + Sync),
+        checkpoint: Option<&TransferCheckpoint>,
+    ) -> Result<Option<TransferCheckpoint>, FmError> {
         // Send an initial "scanning" progress event so the UI shows activity
         on_progress(ProgressEvent {
             id: op_id.to_string(),
@@ -302,11 +325,16 @@ impl SftpService {
             "SFTP download: scan complete, {} files, starting download",
             file_list.len()
         );
-        let bytes_total: u64 = file_list.iter().map(|(_, _, s)| s).sum();
-        let files_total = file_list.len() as u32;
-        let mut bytes_done: u64 = 0;
-        let mut files_done: u32 = 0;
-        let mut completed_files: Vec<String> = Vec::new();
+        let mut bytes_total: u64 = file_list.iter().map(|(_, _, s)| s).sum();
+        let mut files_total = file_list.len() as u32;
+        let mut bytes_done = checkpoint.map_or(0, |c| c.bytes_done);
+        let mut files_done = checkpoint.map_or(0, |c| c.files_done);
+        let mut completed_files = checkpoint.map_or_else(Vec::new, |c| c.files_completed.clone());
+        let completed: HashSet<String> = completed_files.iter().cloned().collect();
+        if let Some(c) = checkpoint {
+            bytes_total = c.bytes_total;
+            files_total = c.files_total;
+        }
 
         for (remote, local, _size) in &file_list {
             if cancel.load(Ordering::Relaxed) {
@@ -320,6 +348,9 @@ impl SftpService {
                     files_done,
                     files_total,
                 }));
+            }
+            if completed.contains(remote) {
+                continue;
             }
 
             // Ensure parent directory exists
@@ -372,6 +403,18 @@ impl SftpService {
             });
         }
 
+        if cancel.load(Ordering::Relaxed) {
+            return Err(FmError::Other("cancelled".into()));
+        }
+        if pause.load(Ordering::Relaxed) {
+            return Ok(Some(TransferCheckpoint {
+                files_completed: completed_files,
+                bytes_done,
+                bytes_total,
+                files_done,
+                files_total,
+            }));
+        }
         Ok(None)
     }
 
@@ -466,6 +509,28 @@ impl SftpService {
         pause: &AtomicBool,
         on_progress: &(dyn Fn(ProgressEvent) + Send + Sync),
     ) -> Result<Option<TransferCheckpoint>, FmError> {
+        self.upload_with_checkpoint(
+            local_paths,
+            remote_dest,
+            op_id,
+            cancel,
+            pause,
+            on_progress,
+            None,
+        )
+        .await
+    }
+
+    pub async fn upload_with_checkpoint(
+        &self,
+        local_paths: &[String],
+        remote_dest: &str,
+        op_id: &str,
+        cancel: &AtomicBool,
+        pause: &AtomicBool,
+        on_progress: &(dyn Fn(ProgressEvent) + Send + Sync),
+        checkpoint: Option<&TransferCheckpoint>,
+    ) -> Result<Option<TransferCheckpoint>, FmError> {
         // Collect all local files
         let mut file_list: Vec<(std::path::PathBuf, String, u64)> = Vec::new();
         for local_path in local_paths {
@@ -484,11 +549,16 @@ impl SftpService {
             }
         }
 
-        let bytes_total: u64 = file_list.iter().map(|(_, _, s)| s).sum();
-        let files_total = file_list.len() as u32;
-        let mut bytes_done: u64 = 0;
-        let mut files_done: u32 = 0;
-        let mut completed_files: Vec<String> = Vec::new();
+        let mut bytes_total: u64 = file_list.iter().map(|(_, _, s)| s).sum();
+        let mut files_total = file_list.len() as u32;
+        let mut bytes_done = checkpoint.map_or(0, |c| c.bytes_done);
+        let mut files_done = checkpoint.map_or(0, |c| c.files_done);
+        let mut completed_files = checkpoint.map_or_else(Vec::new, |c| c.files_completed.clone());
+        let completed: HashSet<String> = completed_files.iter().cloned().collect();
+        if let Some(c) = checkpoint {
+            bytes_total = c.bytes_total;
+            files_total = c.files_total;
+        }
 
         for (local, remote, _size) in &file_list {
             if cancel.load(Ordering::Relaxed) {
@@ -502,6 +572,10 @@ impl SftpService {
                     files_done,
                     files_total,
                 }));
+            }
+            let identity = local.to_string_lossy().into_owned();
+            if completed.contains(&identity) {
+                continue;
             }
 
             // Ensure remote parent directory exists
@@ -523,7 +597,7 @@ impl SftpService {
 
             bytes_done += len;
             files_done += 1;
-            completed_files.push(local.to_string_lossy().into_owned());
+            completed_files.push(identity);
 
             on_progress(ProgressEvent {
                 id: op_id.to_string(),
@@ -538,6 +612,18 @@ impl SftpService {
             });
         }
 
+        if cancel.load(Ordering::Relaxed) {
+            return Err(FmError::Other("cancelled".into()));
+        }
+        if pause.load(Ordering::Relaxed) {
+            return Ok(Some(TransferCheckpoint {
+                files_completed: completed_files,
+                bytes_done,
+                bytes_total,
+                files_done,
+                files_total,
+            }));
+        }
         Ok(None)
     }
 

--- a/src-tauri/tests/local_integration.rs
+++ b/src-tauri/tests/local_integration.rs
@@ -964,3 +964,112 @@ fn copy_cancel_mid_operation() {
     // Should be cancelled (error) since we set cancel after first file progress
     assert!(result.is_err());
 }
+
+#[test]
+fn copy_resume_skips_completed_files_and_accumulates_checkpoint() {
+    let ctx = LocalTestContext::new();
+    ctx.put_file("resume/a.txt", b"first");
+    ctx.put_file("resume/b.txt", b"second");
+    let dst = ctx.create_dest();
+    let sources = vec![ctx.abs("resume")];
+    let flags = OpFlags {
+        cancel: AtomicBool::new(false),
+        pause: AtomicBool::new(false),
+    };
+
+    let pause = &flags.pause;
+    let pause_after_progress = |_event: app_lib::models::ProgressEvent| {
+        pause.store(true, Ordering::Relaxed);
+    };
+    let first = local::copy_files_core_with_checkpoint(
+        "resume-copy",
+        &sources,
+        &dst,
+        &flags,
+        &pause_after_progress,
+        None,
+    )
+    .unwrap()
+    .expect("first pause should return a checkpoint");
+    assert_eq!(first.files_completed.len(), 1);
+
+    let completed_source = std::path::Path::new(&first.files_completed[0]);
+    let relative = completed_source
+        .strip_prefix(ctx.root.path().join("resume"))
+        .unwrap();
+    let completed_dest = std::path::Path::new(&dst).join("resume").join(relative);
+    std::fs::write(&completed_dest, b"sentinel").unwrap();
+
+    flags.pause.store(false, Ordering::Relaxed);
+    let second = local::copy_files_core_with_checkpoint(
+        "resume-copy",
+        &sources,
+        &dst,
+        &flags,
+        &pause_after_progress,
+        Some(&first),
+    )
+    .unwrap()
+    .expect("pause after the final file should return a full checkpoint");
+    assert_eq!(second.files_completed.len(), 2);
+    assert_eq!(second.files_done, 2);
+    assert_eq!(std::fs::read(&completed_dest).unwrap(), b"sentinel");
+
+    flags.pause.store(false, Ordering::Relaxed);
+    let result = local::copy_files_core_with_checkpoint(
+        "resume-copy",
+        &sources,
+        &dst,
+        &flags,
+        &noop_progress(),
+        Some(&second),
+    )
+    .unwrap();
+    assert!(result.is_none());
+    assert_eq!(std::fs::read(&completed_dest).unwrap(), b"sentinel");
+}
+
+#[test]
+fn move_resume_skips_already_renamed_source() {
+    let ctx = LocalTestContext::new();
+    ctx.put_file("first.txt", b"first");
+    ctx.put_file("second.txt", b"second");
+    let dst = ctx.create_dest();
+    let sources = vec![ctx.abs("first.txt"), ctx.abs("second.txt")];
+    let flags = OpFlags {
+        cancel: AtomicBool::new(false),
+        pause: AtomicBool::new(false),
+    };
+
+    let pause = &flags.pause;
+    let pause_after_progress = |_event: app_lib::models::ProgressEvent| {
+        pause.store(true, Ordering::Relaxed);
+    };
+    let checkpoint = local::move_files_core_with_checkpoint(
+        "resume-move",
+        &sources,
+        &dst,
+        &flags,
+        &pause_after_progress,
+        None,
+    )
+    .unwrap()
+    .expect("move should pause after the first rename");
+    assert_eq!(checkpoint.files_completed, vec![sources[0].clone()]);
+    ctx.assert_not_exists("first.txt");
+
+    flags.pause.store(false, Ordering::Relaxed);
+    let result = local::move_files_core_with_checkpoint(
+        "resume-move",
+        &sources,
+        &dst,
+        &flags,
+        &noop_progress(),
+        Some(&checkpoint),
+    )
+    .unwrap();
+    assert!(result.is_none());
+    ctx.assert_file_content("dst/first.txt", b"first");
+    ctx.assert_file_content("dst/second.txt", b"second");
+    ctx.assert_not_exists("second.txt");
+}

--- a/src-tauri/tests/s3_integration.rs
+++ b/src-tauri/tests/s3_integration.rs
@@ -4,7 +4,7 @@ use app_lib::models::S3PublicAccessBlock;
 use app_lib::s3::client::build_s3_client;
 use app_lib::s3::service::{self, S3Service};
 use common::TestContext;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 // ═══════════════════════════════════════════════════════════════════════════
 // P1 — Core CRUD
@@ -1124,6 +1124,67 @@ async fn test_download_files() {
     let c2 = std::fs::read_to_string(tmp_dir.path().join("file2.txt")).unwrap();
     assert_eq!(c1, "content1");
     assert_eq!(c2, "content2");
+
+    ctx.cleanup().await;
+}
+
+#[tokio::test]
+async fn test_download_resume_skips_completed_object() {
+    let ctx = TestContext::new().await;
+    ctx.put_object("resume/first.txt", b"first").await;
+    ctx.put_object("resume/second.txt", b"second").await;
+
+    let keys = vec![
+        "resume/first.txt".to_string(),
+        "resume/second.txt".to_string(),
+    ];
+    let tmp_dir = tempfile::tempdir().expect("tempdir");
+    let cancel = AtomicBool::new(false);
+    let pause = AtomicBool::new(false);
+    let pause_after_first = |event: app_lib::models::ProgressEvent| {
+        if event.files_done == 1 {
+            pause.store(true, Ordering::Relaxed);
+        }
+    };
+
+    let checkpoint = ctx
+        .service
+        .download_with_checkpoint(
+            &keys,
+            tmp_dir.path().to_str().unwrap(),
+            "op-dl-resume",
+            &cancel,
+            &pause,
+            &pause_after_first,
+            None,
+            None,
+        )
+        .await
+        .expect("download failed")
+        .expect("download should pause after the first object");
+    assert_eq!(checkpoint.files_completed.len(), 1);
+
+    let completed_name = checkpoint.files_completed[0].rsplit('/').next().unwrap();
+    let completed_local = tmp_dir.path().join(completed_name);
+    tokio::fs::write(&completed_local, b"sentinel").await.unwrap();
+
+    pause.store(false, Ordering::Relaxed);
+    let result = ctx
+        .service
+        .download_with_checkpoint(
+            &keys,
+            tmp_dir.path().to_str().unwrap(),
+            "op-dl-resume",
+            &cancel,
+            &pause,
+            &|_| {},
+            None,
+            Some(&checkpoint),
+        )
+        .await
+        .expect("resumed download failed");
+    assert!(result.is_none());
+    assert_eq!(tokio::fs::read(&completed_local).await.unwrap(), b"sentinel");
 
     ctx.cleanup().await;
 }

--- a/src-tauri/tests/sftp_integration.rs
+++ b/src-tauri/tests/sftp_integration.rs
@@ -279,6 +279,65 @@ async fn test_download_progress_events() {
 }
 
 #[tokio::test]
+async fn test_download_resume_skips_completed_remote_file() {
+    let ctx = SftpTestContext::new().await;
+    ctx.put_file("resume-a.txt", b"first").await;
+    ctx.put_file("resume-b.txt", b"second").await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let remotes = vec![
+        format!("{}/resume-a.txt", ctx.test_dir),
+        format!("{}/resume-b.txt", ctx.test_dir),
+    ];
+    let cancel = AtomicBool::new(false);
+    let pause = AtomicBool::new(false);
+    let pause_after_first = |event: app_lib::models::ProgressEvent| {
+        if event.files_done == 1 {
+            pause.store(true, Ordering::Relaxed);
+        }
+    };
+
+    let checkpoint = ctx
+        .service
+        .download_with_checkpoint(
+            &remotes,
+            tmp.path().to_str().unwrap(),
+            "op-dl-resume",
+            &cancel,
+            &pause,
+            &pause_after_first,
+            None,
+        )
+        .await
+        .unwrap()
+        .expect("download should pause after the first file");
+    assert_eq!(checkpoint.files_completed.len(), 1);
+
+    let completed_name = checkpoint.files_completed[0].rsplit('/').next().unwrap();
+    let completed_local = tmp.path().join(completed_name);
+    tokio::fs::write(&completed_local, b"sentinel").await.unwrap();
+
+    pause.store(false, Ordering::Relaxed);
+    let result = ctx
+        .service
+        .download_with_checkpoint(
+            &remotes,
+            tmp.path().to_str().unwrap(),
+            "op-dl-resume",
+            &cancel,
+            &pause,
+            &noop_progress(),
+            Some(&checkpoint),
+        )
+        .await
+        .unwrap();
+    assert!(result.is_none());
+    assert_eq!(tokio::fs::read(&completed_local).await.unwrap(), b"sentinel");
+
+    ctx.cleanup().await;
+}
+
+#[tokio::test]
 async fn test_download_scanning_phase() {
     let ctx = SftpTestContext::new().await;
 

--- a/src/lib/actions/sync.ts
+++ b/src/lib/actions/sync.ts
@@ -1,10 +1,9 @@
 import { panels, s3PathToPrefix } from '$lib/state/panels.svelte';
-import { appState } from '$lib/state/app.svelte';
+import { appState, canSyncBackends } from '$lib/state/app.svelte';
 import { statusState } from '$lib/state/status.svelte';
 import { transfersState } from '$lib/state/transfers.svelte';
 import { copyFiles, deleteFiles } from '$lib/services/tauri';
 import { s3Download, s3Upload, s3CopyObjects, s3DeleteObjects } from '$lib/services/s3';
-import { sftpDelete, sftpDownload, sftpUpload } from '$lib/services/sftp';
 import { error } from '$lib/services/log';
 import type { ProgressEvent, SyncEntry, TransferCheckpoint } from '$lib/types';
 
@@ -18,6 +17,10 @@ export function executeSyncTransfer(detail: {
   destS3Id: string;
 }) {
   const { entries, sourceBackend, sourcePath, sourceS3Id, destBackend, destPath, destS3Id } = detail;
+  if (!canSyncBackends(sourceBackend, destBackend)) {
+    statusState.setMessage('Sync not supported for SFTP/archive panels');
+    return;
+  }
 
   const toCopy = entries.filter((e) => e.status === 'new' || e.status === 'modified');
   const toDelete = entries.filter((e) => e.status === 'deleted');
@@ -49,29 +52,6 @@ export function executeSyncTransfer(detail: {
         } else if (sourceBackend === 's3' && destBackend === 's3') {
           const destPrefix = s3PathToPrefix(destPath, '');
           result = await s3CopyObjects(sourceS3Id, opId, copySourcePaths, destS3Id, destPrefix, onProgress);
-        } else if (sourceBackend === 'sftp' && destBackend === 'local') {
-          const sftpId = panels.active.backend === 'sftp' ? panels.active.sftpConnection?.connectionId : panels.inactive.sftpConnection?.connectionId;
-          if (!sftpId) throw new Error('Missing source SFTP connection');
-          result = await sftpDownload(sftpId, opId, copySourcePaths, destPath, onProgress);
-        } else if (sourceBackend === 'local' && destBackend === 'sftp') {
-          const sftpId = panels.active.backend === 'sftp' ? panels.active.sftpConnection?.connectionId : panels.inactive.sftpConnection?.connectionId;
-          if (!sftpId) throw new Error('Missing destination SFTP connection');
-          result = await sftpUpload(sftpId, opId, copySourcePaths, destPath, onProgress);
-        } else if (sourceBackend === 'sftp' && destBackend === 'sftp') {
-          const srcSftpId = panels.active.backend === 'sftp' ? panels.active.sftpConnection?.connectionId : panels.inactive.sftpConnection?.connectionId;
-          const destSftpId = panels.inactive.backend === 'sftp' ? panels.inactive.sftpConnection?.connectionId : panels.active.sftpConnection?.connectionId;
-          if (!srcSftpId || !destSftpId) throw new Error('Missing SFTP connection');
-          const tempDir = `/tmp/furman-sync-${opId}`;
-          result = await sftpDownload(srcSftpId, opId, copySourcePaths, tempDir, onProgress);
-          if (result !== null) {
-            transfersState.markPaused(opId, result);
-            return;
-          }
-          const downloaded = copySourcePaths.map((s) => {
-            const name = s.replace(/\/+$/, '').split('/').pop()!;
-            return `${tempDir}/${name}`;
-          });
-          result = await sftpUpload(destSftpId, opId, downloaded, destPath, onProgress);
         } else {
           throw new Error(`Unsupported sync: ${sourceBackend} -> ${destBackend}`);
         }
@@ -129,12 +109,10 @@ export async function executeSyncDeletes(
   try {
     if (destBackend === 's3') {
       await s3DeleteObjects(destS3Id, 'sync-del-' + Date.now(), deletePaths);
-    } else if (destBackend === 'sftp') {
-      const sftpId = panels.active.backend === 'sftp' ? panels.active.sftpConnection?.connectionId : panels.inactive.sftpConnection?.connectionId;
-      if (!sftpId) throw new Error('Missing destination SFTP connection');
-      await sftpDelete(sftpId, deletePaths);
-    } else {
+    } else if (destBackend === 'local') {
       await deleteFiles(deletePaths, true);
+    } else {
+      throw new Error(`Unsupported sync destination: ${destBackend}`);
     }
     statusState.setMessage(`Deleted ${toDelete.length} file(s) from destination`);
   } catch (err: unknown) {

--- a/src/lib/components/TransferPanel.svelte
+++ b/src/lib/components/TransferPanel.svelte
@@ -191,17 +191,23 @@
         {/if}
         <div class="transfer-actions">
           {#if t.status === 'running'}
-            {#if t.type !== 'delete'}
+            {#if transfersState.canPause(t)}
               <button class="tp-btn" onclick={() => transfersState.pause(t.id)}>Pause</button>
             {/if}
-            <button class="tp-btn tp-btn-cancel" onclick={() => transfersState.cancel(t.id)}>Cancel</button>
+            {#if transfersState.canCancel(t)}
+              <button class="tp-btn tp-btn-cancel" onclick={() => transfersState.cancel(t.id)}>Cancel</button>
+            {/if}
           {:else if t.status === 'paused'}
             <button class="tp-btn" onclick={() => transfersState.resume(t.id)}>Resume</button>
-            <button class="tp-btn tp-btn-cancel" onclick={() => transfersState.cancel(t.id)}>Cancel</button>
+            {#if transfersState.canCancel(t)}
+              <button class="tp-btn tp-btn-cancel" onclick={() => transfersState.cancel(t.id)}>Cancel</button>
+            {/if}
           {:else if t.status === 'queued'}
             <button class="tp-btn" onclick={() => transfersState.moveUp(t.id)} title="Move up">&uarr;</button>
             <button class="tp-btn" onclick={() => transfersState.moveDown(t.id)} title="Move down">&darr;</button>
-            <button class="tp-btn tp-btn-cancel" onclick={() => transfersState.cancel(t.id)}>Cancel</button>
+            {#if transfersState.canCancel(t)}
+              <button class="tp-btn tp-btn-cancel" onclick={() => transfersState.cancel(t.id)}>Cancel</button>
+            {/if}
           {:else}
             <button class="tp-btn" onclick={() => transfersState.dismiss(t.id)}>Dismiss</button>
           {/if}

--- a/src/lib/services/s3.ts
+++ b/src/lib/services/s3.ts
@@ -95,10 +95,11 @@ export async function s3Download(
   destination: string,
   onProgress: (e: ProgressEvent) => void,
   password?: string,
+  checkpoint?: TransferCheckpoint | null,
 ): Promise<TransferCheckpoint | null> {
   const channel = new Channel<ProgressEvent>();
   channel.onmessage = onProgress;
-  return await invoke<TransferCheckpoint | null>('s3_download', { id, opId, keys, destination, password: password ?? null, channel });
+  return await invoke<TransferCheckpoint | null>('s3_download', { id, opId, keys, destination, password: password ?? null, checkpoint: checkpoint ?? null, channel });
 }
 
 export async function s3Upload(
@@ -106,11 +107,12 @@ export async function s3Upload(
   opId: string,
   sources: string[],
   destPrefix: string,
-  onProgress: (e: ProgressEvent) => void
+  onProgress: (e: ProgressEvent) => void,
+  checkpoint?: TransferCheckpoint | null,
 ): Promise<TransferCheckpoint | null> {
   const channel = new Channel<ProgressEvent>();
   channel.onmessage = onProgress;
-  return await invoke<TransferCheckpoint | null>('s3_upload', { id, opId, sources, destPrefix, channel });
+  return await invoke<TransferCheckpoint | null>('s3_upload', { id, opId, sources, destPrefix, checkpoint: checkpoint ?? null, channel });
 }
 
 export async function s3CopyObjects(
@@ -119,11 +121,12 @@ export async function s3CopyObjects(
   srcKeys: string[],
   destId: string,
   destPrefix: string,
-  onProgress: (e: ProgressEvent) => void
+  onProgress: (e: ProgressEvent) => void,
+  checkpoint?: TransferCheckpoint | null,
 ): Promise<TransferCheckpoint | null> {
   const channel = new Channel<ProgressEvent>();
   channel.onmessage = onProgress;
-  return await invoke<TransferCheckpoint | null>('s3_copy_objects', { srcId, opId, srcKeys, destId, destPrefix, channel });
+  return await invoke<TransferCheckpoint | null>('s3_copy_objects', { srcId, opId, srcKeys, destId, destPrefix, checkpoint: checkpoint ?? null, channel });
 }
 
 export async function s3HeadObject(
@@ -514,12 +517,14 @@ export async function s3UploadEncrypted(
   password: string,
   onProgress: (e: ProgressEvent) => void,
   encryptionConfig?: EncryptionConfig,
+  checkpoint?: TransferCheckpoint | null,
 ): Promise<TransferCheckpoint | null> {
   const channel = new Channel<ProgressEvent>();
   channel.onmessage = onProgress;
   return await invoke<TransferCheckpoint | null>('s3_upload_encrypted', {
     id, opId, sources, destPrefix, password,
     encryptionConfig: encryptionConfig ?? null,
+    checkpoint: checkpoint ?? null,
     channel,
   });
 }

--- a/src/lib/services/sftp.ts
+++ b/src/lib/services/sftp.ts
@@ -57,11 +57,12 @@ export async function sftpDownload(
   keys: string[],
   destination: string,
   onProgress: (e: ProgressEvent) => void,
+  checkpoint?: TransferCheckpoint | null,
 ): Promise<TransferCheckpoint | null> {
   const channel = new Channel<ProgressEvent>();
   channel.onmessage = onProgress;
   return await invoke<TransferCheckpoint | null>('sftp_download', {
-    id, opId, keys, destination, channel,
+    id, opId, keys, destination, checkpoint: checkpoint ?? null, channel,
   });
 }
 
@@ -71,11 +72,12 @@ export async function sftpUpload(
   sources: string[],
   remotePrefix: string,
   onProgress: (e: ProgressEvent) => void,
+  checkpoint?: TransferCheckpoint | null,
 ): Promise<TransferCheckpoint | null> {
   const channel = new Channel<ProgressEvent>();
   channel.onmessage = onProgress;
   return await invoke<TransferCheckpoint | null>('sftp_upload', {
-    id, opId, sources, remotePrefix, channel,
+    id, opId, sources, remotePrefix, checkpoint: checkpoint ?? null, channel,
   });
 }
 

--- a/src/lib/services/tauri.ts
+++ b/src/lib/services/tauri.ts
@@ -52,22 +52,24 @@ export async function copyFiles(
   id: string,
   sources: string[],
   destination: string,
-  onProgress: (e: ProgressEvent) => void
+  onProgress: (e: ProgressEvent) => void,
+  checkpoint?: TransferCheckpoint | null,
 ): Promise<TransferCheckpoint | null> {
   const channel = new Channel<ProgressEvent>();
   channel.onmessage = onProgress;
-  return await invoke<TransferCheckpoint | null>('copy_files', { id, sources, destination, channel });
+  return await invoke<TransferCheckpoint | null>('copy_files', { id, sources, destination, checkpoint: checkpoint ?? null, channel });
 }
 
 export async function moveFiles(
   id: string,
   sources: string[],
   destination: string,
-  onProgress: (e: ProgressEvent) => void
+  onProgress: (e: ProgressEvent) => void,
+  checkpoint?: TransferCheckpoint | null,
 ): Promise<TransferCheckpoint | null> {
   const channel = new Channel<ProgressEvent>();
   channel.onmessage = onProgress;
-  return await invoke<TransferCheckpoint | null>('move_files', { id, sources, destination, channel });
+  return await invoke<TransferCheckpoint | null>('move_files', { id, sources, destination, checkpoint: checkpoint ?? null, channel });
 }
 
 export async function cancelFileOperation(id: string): Promise<void> {

--- a/src/lib/state/app.svelte.ts
+++ b/src/lib/state/app.svelte.ts
@@ -8,8 +8,14 @@ import { connectionsState } from '$lib/state/connections.svelte';
 import { s3BookmarksState } from '$lib/state/s3bookmarks.svelte';
 import { sftpBookmarksState } from '$lib/state/sftpbookmarks.svelte';
 import { transfersState } from '$lib/state/transfers.svelte';
+import { statusState } from '$lib/state/status.svelte';
 import { s3SetBandwidthLimit, s3SetMultipartConfig } from '$lib/services/s3';
 import type { ViewMode } from '$lib/types';
+
+export function canSyncBackends(source: string, destination: string): boolean {
+  const supported = (backend: string) => backend === 'local' || backend === 's3';
+  return supported(source) && supported(destination);
+}
 
 class AppState {
   theme = $state<'dark' | 'light'>('dark');
@@ -344,6 +350,10 @@ class AppState {
     source: { backend: PanelBackend; path: string; s3Id: string },
     dest: { backend: PanelBackend; path: string; s3Id: string },
   ) {
+    if (!canSyncBackends(source.backend, dest.backend)) {
+      statusState.setMessage('Sync not supported for SFTP/archive panels');
+      return;
+    }
     this.syncSourceBackend = source.backend;
     this.syncSourcePath = source.path;
     this.syncSourceS3Id = source.s3Id;

--- a/src/lib/state/transfers.svelte.ts
+++ b/src/lib/state/transfers.svelte.ts
@@ -6,6 +6,7 @@ import { formatSize } from '$lib/utils/format';
 
 export type TransferStatus = 'queued' | 'running' | 'paused' | 'completed' | 'failed' | 'cancelled';
 type TransferType = 'copy' | 'move' | 'extract' | 'delete';
+type TransferPhase = 'source-to-staging' | 'staging-ready' | 'staging-to-destination' | 'delete-source-ready' | 'delete-source';
 
 export interface Transfer {
   id: string;
@@ -31,6 +32,9 @@ export interface Transfer {
   encryptionPassword?: string;
   encryptionConfig?: EncryptionConfig;
   checkpoint?: TransferCheckpoint | null;
+  phase?: TransferPhase;
+  pauseRequested?: boolean;
+  cancelRequested?: boolean;
   /** Name to focus in the source panel after a move completes. */
   srcFocusName?: string;
   speedBytesPerSec: number;
@@ -203,6 +207,8 @@ class TransfersState {
     if (t) {
       t.status = 'cancelled';
       t.completedAt = Date.now();
+      t.checkpoint = null;
+      t.phase = undefined;
     }
     this.processQueue();
     if (!this.hasActive && this.queued.length === 0) {
@@ -215,7 +221,7 @@ class TransfersState {
     const t = this.transfers.find((t) => t.id === id);
     if (t) {
       t.status = 'paused';
-      if (checkpoint) t.checkpoint = checkpoint;
+      t.checkpoint = checkpoint ?? null;
     }
     this.processQueue();
   }
@@ -223,14 +229,14 @@ class TransfersState {
   async cancel(id: string) {
     const t = this.transfers.find((t) => t.id === id);
     if (!t) return;
+    if (t.phase === 'delete-source') return;
 
-    if (t.status === 'queued') {
-      // Never started — just remove
-      t.status = 'cancelled';
-      t.completedAt = Date.now();
+    if (t.status === 'queued' || t.status === 'paused') {
+      this.markCancelled(id);
       return;
     }
 
+    t.cancelRequested = true;
     try {
       await cancelFileOperation(id);
     } catch {
@@ -242,6 +248,7 @@ class TransfersState {
     const t = this.transfers.find((t) => t.id === id);
     if (!t || t.status !== 'running') return;
 
+    t.pauseRequested = true;
     try {
       await pauseFileOperation(id);
       // The backend will return a checkpoint via the dispatch promise,
@@ -254,6 +261,8 @@ class TransfersState {
   resume(id: string) {
     const t = this.transfers.find((t) => t.id === id);
     if (!t || t.status !== 'paused') return;
+    t.pauseRequested = false;
+    t.cancelRequested = false;
     t.status = 'queued';
     t.priority = Date.now();
     this.processQueue();
@@ -291,6 +300,14 @@ class TransfersState {
     this.panelVisible = !this.panelVisible;
   }
 
+  canPause(t: Transfer): boolean {
+    return (t.type === 'copy' || t.type === 'move') && !t.id.startsWith('sync-') && t.phase !== 'delete-source';
+  }
+
+  canCancel(t: Transfer): boolean {
+    return t.phase !== 'delete-source';
+  }
+
   /** Dispatch a transfer to the appropriate backend. */
   private async dispatchTransfer(t: Transfer) {
     const onProgress = (e: ProgressEvent) => {
@@ -313,11 +330,15 @@ class TransfersState {
       }
 
       // Check if paused (backend returned checkpoint)
-      if (result) {
+      if (result !== null && result !== undefined) {
+        this.throwIfCancelled(t);
         this.markPaused(t.id, result);
         return;
       }
 
+      this.throwIfCancelled(t);
+      t.checkpoint = null;
+      t.phase = undefined;
       this.complete(t.id);
     } catch (err: unknown) {
       const msg = String(err);
@@ -335,154 +356,204 @@ class TransfersState {
   ): Promise<TransferCheckpoint | null> {
     const { srcBackend, destBackend } = t;
 
+    if (t.type === 'move' && t.phase === 'delete-source-ready') {
+      t.phase = 'delete-source';
+      await this.deleteMoveSources(t);
+      return null;
+    }
+
     if (t.type === 'copy') {
       if (srcBackend === 'local' && destBackend === 'local') {
-        return await copyFiles(t.id, t.sources, t.destination, onProgress);
+        return await copyFiles(t.id, t.sources, t.destination, onProgress, t.checkpoint);
       }
       if (srcBackend === 's3' && destBackend === 'local') {
-        return await s3Download(t.s3SrcConnectionId!, t.id, t.sources, t.destination, onProgress, t.encryptionPassword);
+        return await s3Download(t.s3SrcConnectionId!, t.id, t.sources, t.destination, onProgress, t.encryptionPassword, t.checkpoint);
       }
       if (srcBackend === 'local' && destBackend === 's3') {
         if (t.encryptionPassword) {
-          return await s3UploadEncrypted(t.s3DestConnectionId!, t.id, t.sources, t.s3DestPrefix!, t.encryptionPassword, onProgress, t.encryptionConfig);
+          return await s3UploadEncrypted(t.s3DestConnectionId!, t.id, t.sources, t.s3DestPrefix!, t.encryptionPassword, onProgress, t.encryptionConfig, t.checkpoint);
         }
-        return await s3Upload(t.s3DestConnectionId!, t.id, t.sources, t.s3DestPrefix!, onProgress);
+        return await s3Upload(t.s3DestConnectionId!, t.id, t.sources, t.s3DestPrefix!, onProgress, t.checkpoint);
       }
       if (srcBackend === 's3' && destBackend === 's3') {
         return await s3CopyObjects(
           t.s3SrcConnectionId!, t.id, t.sources,
-          t.s3DestConnectionId!, t.s3DestPrefix!, onProgress,
+          t.s3DestConnectionId!, t.s3DestPrefix!, onProgress, t.checkpoint,
         );
       }
       // SFTP transfers
       if (srcBackend === 'sftp' && destBackend === 'local') {
-        return await sftpDownload(t.sftpSrcConnectionId!, t.id, t.sources, t.destination, onProgress);
+        return await sftpDownload(t.sftpSrcConnectionId!, t.id, t.sources, t.destination, onProgress, t.checkpoint);
       }
       if (srcBackend === 'local' && destBackend === 'sftp') {
-        return await sftpUpload(t.sftpDestConnectionId!, t.id, t.sources, t.sftpDestPath!, onProgress);
+        return await sftpUpload(t.sftpDestConnectionId!, t.id, t.sources, t.sftpDestPath!, onProgress, t.checkpoint);
       }
       if (srcBackend === 'sftp' && destBackend === 'sftp') {
-        // No server-side copy in SFTP — download to temp then upload
-        const tempDir = `/tmp/furman-xfer-${t.id}`;
-        const stagingResult = await sftpDownload(t.sftpSrcConnectionId!, t.id, t.sources, tempDir, onProgress);
-        if (stagingResult !== null) return stagingResult;
-        // Build list of downloaded files for upload
-        const downloaded = t.sources.map((s) => {
-          const name = s.replace(/\/+$/, '').split('/').pop()!;
-          return `${tempDir}/${name}`;
-        });
-        return await sftpUpload(t.sftpDestConnectionId!, t.id, downloaded, t.sftpDestPath!, onProgress);
+        return await this.dispatchStaged(
+          t,
+          (tempDir, checkpoint) => sftpDownload(t.sftpSrcConnectionId!, t.id, t.sources, tempDir, onProgress, checkpoint),
+          (downloaded, checkpoint) => sftpUpload(t.sftpDestConnectionId!, t.id, downloaded, t.sftpDestPath!, onProgress, checkpoint),
+        );
       }
       // Cross-protocol: S3 ↔ SFTP (via temp dir)
       if (srcBackend === 's3' && destBackend === 'sftp') {
-        const tempDir = `/tmp/furman-xfer-${t.id}`;
-        const stagingResult = await s3Download(t.s3SrcConnectionId!, t.id, t.sources, tempDir, onProgress, t.encryptionPassword);
-        if (stagingResult !== null) return stagingResult;
-        const downloaded = t.sources.map((s) => {
-          const name = s.replace(/\/+$/, '').split('/').pop()!;
-          return `${tempDir}/${name}`;
-        });
-        return await sftpUpload(t.sftpDestConnectionId!, t.id, downloaded, t.sftpDestPath!, onProgress);
+        return await this.dispatchStaged(
+          t,
+          (tempDir, checkpoint) => s3Download(t.s3SrcConnectionId!, t.id, t.sources, tempDir, onProgress, t.encryptionPassword, checkpoint),
+          (downloaded, checkpoint) => sftpUpload(t.sftpDestConnectionId!, t.id, downloaded, t.sftpDestPath!, onProgress, checkpoint),
+        );
       }
       if (srcBackend === 'sftp' && destBackend === 's3') {
-        const tempDir = `/tmp/furman-xfer-${t.id}`;
-        const stagingResult = await sftpDownload(t.sftpSrcConnectionId!, t.id, t.sources, tempDir, onProgress);
-        if (stagingResult !== null) return stagingResult;
-        const downloaded = t.sources.map((s) => {
-          const name = s.replace(/\/+$/, '').split('/').pop()!;
-          return `${tempDir}/${name}`;
-        });
-        return await s3Upload(t.s3DestConnectionId!, t.id, downloaded, t.s3DestPrefix!, onProgress);
+        return await this.dispatchStaged(
+          t,
+          (tempDir, checkpoint) => sftpDownload(t.sftpSrcConnectionId!, t.id, t.sources, tempDir, onProgress, checkpoint),
+          (downloaded, checkpoint) => s3Upload(t.s3DestConnectionId!, t.id, downloaded, t.s3DestPrefix!, onProgress, checkpoint),
+        );
       }
     }
 
     if (t.type === 'move') {
       if (srcBackend === 'local' && destBackend === 'local') {
-        return await moveFiles(t.id, t.sources, t.destination, onProgress);
+        return await moveFiles(t.id, t.sources, t.destination, onProgress, t.checkpoint);
       }
       // S3 move = copy/download + delete source
       if (srcBackend === 's3' && destBackend === 'local') {
-        const result = await s3Download(t.s3SrcConnectionId!, t.id, t.sources, t.destination, onProgress, t.encryptionPassword);
+        const result = await s3Download(t.s3SrcConnectionId!, t.id, t.sources, t.destination, onProgress, t.encryptionPassword, t.checkpoint);
         if (result !== null) return result;
-        await s3DeleteObjects(t.s3SrcConnectionId!, t.id + '-del', t.sources);
-        return null;
+        return await this.finishMove(t);
       }
       if (srcBackend === 'local' && destBackend === 's3') {
         let result;
         if (t.encryptionPassword) {
-          result = await s3UploadEncrypted(t.s3DestConnectionId!, t.id, t.sources, t.s3DestPrefix!, t.encryptionPassword, onProgress, t.encryptionConfig);
+          result = await s3UploadEncrypted(t.s3DestConnectionId!, t.id, t.sources, t.s3DestPrefix!, t.encryptionPassword, onProgress, t.encryptionConfig, t.checkpoint);
         } else {
-          result = await s3Upload(t.s3DestConnectionId!, t.id, t.sources, t.s3DestPrefix!, onProgress);
+          result = await s3Upload(t.s3DestConnectionId!, t.id, t.sources, t.s3DestPrefix!, onProgress, t.checkpoint);
         }
         if (result !== null) return result;
-        await deleteFiles(t.sources, true);
-        return null;
+        return await this.finishMove(t);
       }
       if (srcBackend === 's3' && destBackend === 's3') {
         const result = await s3CopyObjects(
           t.s3SrcConnectionId!, t.id, t.sources,
-          t.s3DestConnectionId!, t.s3DestPrefix!, onProgress,
+          t.s3DestConnectionId!, t.s3DestPrefix!, onProgress, t.checkpoint,
         );
         if (result !== null) return result;
-        await s3DeleteObjects(t.s3SrcConnectionId!, t.id + '-del', t.sources);
-        return null;
+        return await this.finishMove(t);
       }
       // SFTP move = download/upload + delete source
       if (srcBackend === 'sftp' && destBackend === 'local') {
-        const result = await sftpDownload(t.sftpSrcConnectionId!, t.id, t.sources, t.destination, onProgress);
+        const result = await sftpDownload(t.sftpSrcConnectionId!, t.id, t.sources, t.destination, onProgress, t.checkpoint);
         if (result !== null) return result;
-        await sftpDelete(t.sftpSrcConnectionId!, t.sources);
-        return null;
+        return await this.finishMove(t);
       }
       if (srcBackend === 'local' && destBackend === 'sftp') {
-        const result = await sftpUpload(t.sftpDestConnectionId!, t.id, t.sources, t.sftpDestPath!, onProgress);
+        const result = await sftpUpload(t.sftpDestConnectionId!, t.id, t.sources, t.sftpDestPath!, onProgress, t.checkpoint);
         if (result !== null) return result;
-        await deleteFiles(t.sources, true);
-        return null;
+        return await this.finishMove(t);
       }
       if (srcBackend === 'sftp' && destBackend === 'sftp') {
-        const tempDir = `/tmp/furman-xfer-${t.id}`;
-        const stagingResult = await sftpDownload(t.sftpSrcConnectionId!, t.id, t.sources, tempDir, onProgress);
-        if (stagingResult !== null) return stagingResult;
-        const downloaded = t.sources.map((s) => {
-          const name = s.replace(/\/+$/, '').split('/').pop()!;
-          return `${tempDir}/${name}`;
-        });
-        const result = await sftpUpload(t.sftpDestConnectionId!, t.id, downloaded, t.sftpDestPath!, onProgress);
+        const result = await this.dispatchStaged(
+          t,
+          (tempDir, checkpoint) => sftpDownload(t.sftpSrcConnectionId!, t.id, t.sources, tempDir, onProgress, checkpoint),
+          (downloaded, checkpoint) => sftpUpload(t.sftpDestConnectionId!, t.id, downloaded, t.sftpDestPath!, onProgress, checkpoint),
+        );
         if (result !== null) return result;
-        await sftpDelete(t.sftpSrcConnectionId!, t.sources);
-        return null;
+        return await this.finishMove(t);
       }
       // Cross-protocol: S3 ↔ SFTP (via temp dir)
       if (srcBackend === 's3' && destBackend === 'sftp') {
-        const tempDir = `/tmp/furman-xfer-${t.id}`;
-        const stagingResult = await s3Download(t.s3SrcConnectionId!, t.id, t.sources, tempDir, onProgress, t.encryptionPassword);
-        if (stagingResult !== null) return stagingResult;
-        const downloaded = t.sources.map((s) => {
-          const name = s.replace(/\/+$/, '').split('/').pop()!;
-          return `${tempDir}/${name}`;
-        });
-        const result = await sftpUpload(t.sftpDestConnectionId!, t.id, downloaded, t.sftpDestPath!, onProgress);
+        const result = await this.dispatchStaged(
+          t,
+          (tempDir, checkpoint) => s3Download(t.s3SrcConnectionId!, t.id, t.sources, tempDir, onProgress, t.encryptionPassword, checkpoint),
+          (downloaded, checkpoint) => sftpUpload(t.sftpDestConnectionId!, t.id, downloaded, t.sftpDestPath!, onProgress, checkpoint),
+        );
         if (result !== null) return result;
-        await s3DeleteObjects(t.s3SrcConnectionId!, t.id + '-del', t.sources);
-        return null;
+        return await this.finishMove(t);
       }
       if (srcBackend === 'sftp' && destBackend === 's3') {
-        const tempDir = `/tmp/furman-xfer-${t.id}`;
-        const stagingResult = await sftpDownload(t.sftpSrcConnectionId!, t.id, t.sources, tempDir, onProgress);
-        if (stagingResult !== null) return stagingResult;
-        const downloaded = t.sources.map((s) => {
-          const name = s.replace(/\/+$/, '').split('/').pop()!;
-          return `${tempDir}/${name}`;
-        });
-        const result = await s3Upload(t.s3DestConnectionId!, t.id, downloaded, t.s3DestPrefix!, onProgress);
+        const result = await this.dispatchStaged(
+          t,
+          (tempDir, checkpoint) => sftpDownload(t.sftpSrcConnectionId!, t.id, t.sources, tempDir, onProgress, checkpoint),
+          (downloaded, checkpoint) => s3Upload(t.s3DestConnectionId!, t.id, downloaded, t.s3DestPrefix!, onProgress, checkpoint),
+        );
         if (result !== null) return result;
-        await sftpDelete(t.sftpSrcConnectionId!, t.sources);
-        return null;
+        return await this.finishMove(t);
       }
     }
 
     throw new Error(`Unsupported transfer: ${t.type} ${srcBackend} -> ${destBackend}`);
+  }
+
+  private async dispatchStaged(
+    t: Transfer,
+    download: (tempDir: string, checkpoint: TransferCheckpoint | null) => Promise<TransferCheckpoint | null>,
+    upload: (sources: string[], checkpoint: TransferCheckpoint | null) => Promise<TransferCheckpoint | null>,
+  ): Promise<TransferCheckpoint | null> {
+    const tempDir = `/tmp/furman-xfer-${t.id}`;
+
+    if (t.phase !== 'staging-ready' && t.phase !== 'staging-to-destination') {
+      const checkpoint = t.phase === 'source-to-staging' ? t.checkpoint ?? null : null;
+      const result = await download(tempDir, checkpoint);
+      if (result !== null) {
+        t.phase = 'source-to-staging';
+        return result;
+      }
+      this.throwIfCancelled(t);
+      t.checkpoint = null;
+      t.phase = 'staging-ready';
+      if (t.pauseRequested) return this.boundaryCheckpoint(t);
+    }
+
+    const downloaded = t.sources.map((source) => {
+      const name = source.replace(/\/+$/, '').split('/').pop()!;
+      return `${tempDir}/${name}`;
+    });
+    const checkpoint = t.phase === 'staging-to-destination' ? t.checkpoint ?? null : null;
+    t.phase = 'staging-to-destination';
+    const result = await upload(downloaded, checkpoint);
+    if (result !== null) return result;
+    this.throwIfCancelled(t);
+    t.checkpoint = null;
+    return null;
+  }
+
+  private async finishMove(t: Transfer): Promise<TransferCheckpoint | null> {
+    this.throwIfCancelled(t);
+    if (t.pauseRequested) {
+      t.phase = 'delete-source-ready';
+      return this.boundaryCheckpoint(t);
+    }
+    t.phase = 'delete-source';
+    await this.deleteMoveSources(t);
+    return null;
+  }
+
+  private async deleteMoveSources(t: Transfer) {
+    this.throwIfCancelled(t);
+    if (t.srcBackend === 's3') {
+      await s3DeleteObjects(t.s3SrcConnectionId!, t.id + '-del', t.sources);
+    } else if (t.srcBackend === 'sftp') {
+      await sftpDelete(t.sftpSrcConnectionId!, t.sources);
+    } else if (t.srcBackend === 'local') {
+      await deleteFiles(t.sources, true);
+    } else {
+      throw new Error(`Unsupported move source: ${t.srcBackend}`);
+    }
+  }
+
+  private throwIfCancelled(t: Transfer) {
+    if (t.cancelRequested) throw new Error('cancelled');
+  }
+
+  private boundaryCheckpoint(t: Transfer): TransferCheckpoint {
+    const progress = t.progress;
+    return {
+      files_completed: [],
+      bytes_done: progress?.bytes_done ?? 0,
+      bytes_total: progress?.bytes_total ?? 0,
+      files_done: progress?.files_done ?? 0,
+      files_total: progress?.files_total ?? 0,
+    };
   }
 }
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,7 +5,7 @@
   import { listen } from '@tauri-apps/api/event';
   import { invoke } from '@tauri-apps/api/core';
   import { panels, s3PathToPrefix } from '$lib/state/panels.svelte';
-  import { appState } from '$lib/state/app.svelte';
+  import { appState, canSyncBackends } from '$lib/state/app.svelte';
   import { terminalState } from '$lib/state/terminal.svelte';
   import { sidebarState } from '$lib/state/sidebar.svelte';
   import { workspacesState } from '$lib/state/workspaces.svelte';
@@ -176,6 +176,7 @@
     const isS3 = () => panels.active.backend === 's3';
     const isSftp = () => panels.active.backend === 'sftp';
     const isLocal = () => panels.active.backend === 'local';
+    const canSync = () => canSyncBackends(panels.active.backend, panels.inactive.backend);
 
     const cmds: Command[] = [
       // File operations
@@ -257,13 +258,11 @@
       { id: 'sync', label: 'Sync directories', shortcut: `${mod}Y`, category: 'Panel', execute: () => {
         const src = panels.active;
         const dst = panels.inactive;
-        if (src.backend !== 'archive' && dst.backend !== 'archive') {
-          appState.showSync(
-            { backend: src.backend, path: src.path, s3Id: src.s3Connection?.connectionId ?? '' },
-            { backend: dst.backend, path: dst.path, s3Id: dst.s3Connection?.connectionId ?? '' },
-          );
-        }
-      }},
+        appState.showSync(
+          { backend: src.backend, path: src.path, s3Id: src.s3Connection?.connectionId ?? '' },
+          { backend: dst.backend, path: dst.path, s3Id: dst.s3Connection?.connectionId ?? '' },
+        );
+      }, enabled: canSync },
       { id: 'new-tab', label: 'New tab', shortcut: `${mod}${alt}T`, category: 'Panel', execute: () => {
         const side = panels.activePanel;
         const path = panels.active.path;
@@ -777,12 +776,10 @@
       case 'sync': {
         const src = panels.active;
         const dst = panels.inactive;
-        if (src.backend !== 'archive' && dst.backend !== 'archive') {
-          appState.showSync(
-            { backend: src.backend, path: src.path, s3Id: src.s3Connection?.connectionId ?? '' },
-            { backend: dst.backend, path: dst.path, s3Id: dst.s3Connection?.connectionId ?? '' },
-          );
-        }
+        appState.showSync(
+          { backend: src.backend, path: src.path, s3Id: src.s3Connection?.connectionId ?? '' },
+          { backend: dst.backend, path: dst.path, s3Id: dst.s3Connection?.connectionId ?? '' },
+        );
         break;
       }
       case 'shortcuts':


### PR DESCRIPTION
## Summary

- consume transfer checkpoints across local, S3, and SFTP backends so completed files are skipped on resume
- track staged download/upload phases for SFTP-to-SFTP and S3/SFTP transfers
- honor late pause and cancellation requests before committing move source deletion
- disable unsupported SFTP/archive sync at command, modal, and execution boundaries
- add local, S3, and SFTP resume regression coverage and update documentation

## Validation

- `npm run check`
- `npm run lint`
- `npm run build`
- `cargo test --locked --lib` (14 passed)
- `cargo test --locked --test local_integration` (61 passed)
- `cargo test --locked --no-run`
- `cargo check --locked --features mcp --bin furman-mcp`
- `git diff --check`

## Notes

- Resume is file-granular; an in-progress individual file restarts, while previously completed files are skipped.
- S3 and SFTP integration tests compile locally but require their Docker test services to execute; GitHub Actions will run them.