### PR TITLE
Fix temp cleanup and comparison filters

### DIFF
--- a/src-tauri/src/commands/archive.rs
+++ b/src-tauri/src/commands/archive.rs
@@ -327,10 +327,8 @@ pub fn extract_archive_to_temp(
         return Err(FmError::NotFound(archive_path.clone()));
     }
 
-    // Create a temporary directory for the extraction
-    let tmp_dir = std::env::temp_dir().join("furman-archive-preview");
-    std::fs::create_dir_all(&tmp_dir)
-        .map_err(|e| FmError::Other(format!("Failed to create temp dir: {e}")))?;
+    let safe_internal_path = crate::commands::temp::safe_relative_path(&internal_path)?;
+    let tmp_dir = crate::commands::temp::create_temp_dir_path("archive")?;
 
     let output = Command::new("7z")
         .args([
@@ -338,10 +336,13 @@ pub fn extract_archive_to_temp(
             &archive_path,
             &format!("-o{}", tmp_dir.display()),
             "-y",
+            "-spd",
+            "--",
             &internal_path,
         ])
         .output()
         .map_err(|e| {
+            let _ = std::fs::remove_dir_all(&tmp_dir);
             if e.kind() == std::io::ErrorKind::NotFound {
                 #[cfg(target_os = "macos")]
                 { FmError::Other("7z not found. Install with: brew install 7zip".to_string()) }
@@ -354,15 +355,38 @@ pub fn extract_archive_to_temp(
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        let _ = std::fs::remove_dir_all(&tmp_dir);
         return Err(FmError::Other(format!("7z extract failed: {stderr}")));
     }
 
-    let extracted = tmp_dir.join(&internal_path);
-    if !extracted.exists() {
-        return Err(FmError::NotFound(format!(
-            "Extracted file not found: {}",
-            extracted.display()
-        )));
+    let extracted = tmp_dir.join(safe_internal_path);
+    let canonical_tmp_dir = match std::fs::canonicalize(&tmp_dir) {
+        Ok(path) => path,
+        Err(error) => {
+            let _ = std::fs::remove_dir_all(&tmp_dir);
+            return Err(FmError::Io(error));
+        }
+    };
+    let canonical_extracted = match std::fs::canonicalize(&extracted) {
+        Ok(path) => path,
+        Err(error) => {
+            let _ = std::fs::remove_dir_all(&tmp_dir);
+            return Err(if error.kind() == std::io::ErrorKind::NotFound {
+                FmError::NotFound(format!("Extracted file not found: {}", extracted.display()))
+            } else {
+                FmError::Io(error)
+            });
+        }
+    };
+    let is_regular_file = canonical_extracted
+        .metadata()
+        .map(|metadata| metadata.is_file())
+        .unwrap_or(false);
+    if !canonical_extracted.starts_with(&canonical_tmp_dir) || !is_regular_file {
+        let _ = std::fs::remove_dir_all(&tmp_dir);
+        return Err(FmError::Other(
+            "Archive entry did not extract to a regular file".into(),
+        ));
     }
 
     Ok(extracted.to_string_lossy().into_owned())
@@ -391,6 +415,12 @@ pub fn extract_archive(
     if !dest.exists() {
         return Err(FmError::NotFound(destination.clone()));
     }
+    if internal_paths.is_empty() {
+        return Err(FmError::Other("No archive entries selected".into()));
+    }
+    for path in &internal_paths {
+        crate::commands::temp::safe_relative_path(path)?;
+    }
 
     let files_total = internal_paths.len() as u32;
 
@@ -398,18 +428,16 @@ pub fn extract_archive(
         cancel: AtomicBool::new(false),
         pause: AtomicBool::new(false),
     });
-    {
-        let mut map = state.0.lock().map_err(|e| FmError::Other(e.to_string()))?;
-        map.insert(id.clone(), flags.clone());
-    }
 
     // Use `7z x` to extract with full paths, targeting specific files.
-    // -o sets output directory, -y auto-confirms overwrites.
+    // -o sets output directory, -y auto-confirms overwrites, -spd treats names literally.
     let mut args = vec![
         "x".to_string(),
         archive_path.clone(),
         format!("-o{destination}"),
         "-y".to_string(),
+        "-spd".to_string(),
+        "--".to_string(),
     ];
     for p in &internal_paths {
         args.push(p.clone());
@@ -428,6 +456,18 @@ pub fn extract_archive(
                 FmError::Other(format!("Failed to run 7z: {e}"))
             }
         })?;
+
+    {
+        let mut map = match state.0.lock() {
+            Ok(map) => map,
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(FmError::Other(error.to_string()));
+            }
+        };
+        map.insert(id.clone(), flags.clone());
+    }
 
     // Poll the child process, checking cancel flag between polls.
     let result = loop {

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod s3;
 pub mod search;
 pub mod sftp;
 pub mod sync;
+pub mod temp;
 pub mod terminal;
 pub mod volumes;
 pub mod watcher;

--- a/src-tauri/src/commands/temp.rs
+++ b/src-tauri/src/commands/temp.rs
@@ -1,0 +1,152 @@
+use crate::models::FmError;
+#[cfg(unix)]
+use std::os::unix::fs::DirBuilderExt;
+use std::path::{Component, Path, PathBuf};
+
+fn validate_category(category: &str) -> Result<(), FmError> {
+    if category.is_empty()
+        || !category
+            .bytes()
+            .all(|c| c.is_ascii_alphanumeric() || c == b'-' || c == b'_')
+    {
+        return Err(FmError::Other("Invalid temp category".into()));
+    }
+    Ok(())
+}
+
+pub fn create_temp_dir_path(category: &str) -> Result<PathBuf, FmError> {
+    validate_category(category)?;
+    for _ in 0..10 {
+        let path = std::env::temp_dir().join(format!("furman-{category}-{}", uuid::Uuid::new_v4()));
+        let result = {
+            let mut builder = std::fs::DirBuilder::new();
+            #[cfg(unix)]
+            builder.mode(0o700);
+            builder.create(&path)
+        };
+        match result {
+            Ok(()) => return Ok(path),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(FmError::Io(error)),
+        }
+    }
+    Err(FmError::Other(
+        "Failed to allocate unique temp directory".into(),
+    ))
+}
+
+pub fn safe_filename(name: &str) -> String {
+    let filename = Path::new(name)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("file");
+    if filename.is_empty() || filename == "." || filename == ".." {
+        "file".to_string()
+    } else {
+        filename.to_string()
+    }
+}
+
+pub fn safe_relative_path(path: &str) -> Result<PathBuf, FmError> {
+    let path = Path::new(path);
+    if path.as_os_str().is_empty()
+        || path.to_string_lossy().starts_with(['-', '@'])
+        || path
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(FmError::Other("Invalid archive path".into()));
+    }
+    Ok(path.to_path_buf())
+}
+
+fn allocation_root(path: &Path) -> Result<PathBuf, FmError> {
+    let platform_root = std::env::temp_dir();
+    let root = std::fs::canonicalize(&platform_root).unwrap_or_else(|_| platform_root.clone());
+    let normalized_path = match path.strip_prefix(&platform_root) {
+        Ok(relative) => root.join(relative),
+        Err(_) => path.to_path_buf(),
+    };
+    let relative = normalized_path
+        .strip_prefix(&root)
+        .map_err(|_| FmError::Other("Refusing to clean path outside Furman temp root".into()))?;
+    let mut components = relative.components();
+    let allocation_name = match components.next() {
+        Some(Component::Normal(value)) => value.to_string_lossy(),
+        _ => return Err(FmError::Other("Invalid Furman temp path".into())),
+    };
+    let value = allocation_name
+        .strip_prefix("furman-")
+        .ok_or_else(|| FmError::Other("Invalid Furman temp allocation".into()))?;
+    if value.len() < 38 {
+        return Err(FmError::Other("Invalid Furman temp allocation".into()));
+    }
+    let category = value
+        .get(..value.len() - 37)
+        .ok_or_else(|| FmError::Other("Invalid Furman temp allocation".into()))?;
+    validate_category(category)?;
+    let separator = value
+        .get(value.len() - 37..value.len() - 36)
+        .ok_or_else(|| FmError::Other("Invalid Furman temp allocation".into()))?;
+    if separator != "-" {
+        return Err(FmError::Other("Invalid Furman temp allocation".into()));
+    }
+    let id = value
+        .get(value.len() - 36..)
+        .ok_or_else(|| FmError::Other("Invalid Furman temp allocation".into()))?;
+    uuid::Uuid::parse_str(id)
+        .map_err(|_| FmError::Other("Invalid Furman temp allocation".into()))?;
+    Ok(root.join(allocation_name.as_ref()))
+}
+
+#[tauri::command]
+pub fn create_temp_dir(category: String) -> Result<String, FmError> {
+    Ok(create_temp_dir_path(&category)?
+        .to_string_lossy()
+        .into_owned())
+}
+
+#[tauri::command]
+pub fn cleanup_temp_path(path: String) -> Result<(), FmError> {
+    let allocation = allocation_root(Path::new(&path))?;
+    match std::fs::remove_dir_all(allocation) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(FmError::Io(error)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allocations_are_unique_and_cleanup_is_recursive() {
+        let first = create_temp_dir_path("test").unwrap();
+        let second = create_temp_dir_path("test").unwrap();
+        let canonical_second = std::fs::canonicalize(&second).unwrap();
+        assert_ne!(first, second);
+        std::fs::create_dir_all(first.join("nested")).unwrap();
+        std::fs::write(first.join("nested/file.txt"), b"data").unwrap();
+
+        cleanup_temp_path(first.join("nested/file.txt").to_string_lossy().into_owned()).unwrap();
+        assert!(!first.exists());
+        cleanup_temp_path(first.to_string_lossy().into_owned()).unwrap();
+        cleanup_temp_path(canonical_second.to_string_lossy().into_owned()).unwrap();
+    }
+
+    #[test]
+    fn cleanup_rejects_paths_outside_temp_root() {
+        let result = cleanup_temp_path(std::env::temp_dir().to_string_lossy().into_owned());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn relative_archive_paths_reject_traversal() {
+        assert!(safe_relative_path("folder/file.txt").is_ok());
+        assert!(safe_relative_path("../file.txt").is_err());
+        assert!(safe_relative_path("/file.txt").is_err());
+        assert!(safe_relative_path("-spf").is_err());
+        assert!(safe_relative_path("@files.txt").is_err());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -246,6 +246,8 @@ pub fn run() {
             commands::file::restore_from_trash,
             commands::file::cancel_file_operation,
             commands::file::pause_file_operation,
+            commands::temp::create_temp_dir,
+            commands::temp::cleanup_temp_path,
             // metadata / content commands
             commands::metadata::read_file_text,
             commands::metadata::write_file_text,

--- a/src-tauri/src/s3/service.rs
+++ b/src-tauri/src/s3/service.rs
@@ -1504,48 +1504,49 @@ impl S3Service {
             )));
         }
 
-        // Build temp path: {temp}/furman-preview/{hash}-{filename}
-        let filename = stripped_key.rsplit('/').next().unwrap_or(&stripped_key);
-        let hash = {
-            use std::hash::{Hash, Hasher};
-            let mut hasher = std::collections::hash_map::DefaultHasher::new();
-            key.hash(&mut hasher);
-            format!("{:016x}", hasher.finish())
-        };
-        let safe_name = format!("{}-{}", &hash[..8], filename);
-        let temp_path = std::env::temp_dir().join("furman-preview").join(&safe_name);
+        let filename = crate::commands::temp::safe_filename(
+            stripped_key.rsplit('/').next().unwrap_or(&stripped_key),
+        );
+        let temp_dir = crate::commands::temp::create_temp_dir_path("preview")?;
+        let temp_path = temp_dir.join(filename);
 
-        if let Some(parent) = temp_path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
+        let result: Result<(), FmError> = async {
+            let resp = self
+                .client
+                .get_object()
+                .bucket(&self.bucket)
+                .key(&stripped_key)
+                .send()
+                .await
+                .map_err(|e| s3err(e.to_string()))?;
 
-        // Download the object
-        let resp = self
-            .client
-            .get_object()
-            .bucket(&self.bucket)
-            .key(&stripped_key)
-            .send()
-            .await
-            .map_err(|e| s3err(e.to_string()))?;
+            let obj_metadata: HashMap<String, String> =
+                resp.metadata().cloned().unwrap_or_default();
+            let body = resp
+                .body
+                .collect()
+                .await
+                .map_err(|e| s3err(e.to_string()))?;
+            tokio::fs::write(&temp_path, body.into_bytes())
+                .await
+                .map_err(FmError::Io)?;
 
-        let obj_metadata: HashMap<String, String> = resp.metadata().cloned().unwrap_or_default();
-        let body = resp
-            .body
-            .collect()
-            .await
-            .map_err(|e| s3err(e.to_string()))?;
-        std::fs::write(&temp_path, body.into_bytes())?;
-
-        // Decrypt if encrypted
-        if let Some(pw) = password {
-            if let Some(enc_params) = super::crypto::EncryptionParams::from_metadata(&obj_metadata)
-            {
-                super::crypto::decrypt_file(&temp_path, pw, &enc_params)?;
+            if let Some(pw) = password {
+                if let Some(enc_params) =
+                    super::crypto::EncryptionParams::from_metadata(&obj_metadata)
+                {
+                    super::crypto::decrypt_file(&temp_path, pw, &enc_params)?;
+                }
+            } else if super::crypto::EncryptionParams::is_encrypted(&obj_metadata) {
+                return Err(s3err("File is encrypted — password required"));
             }
-        } else if super::crypto::EncryptionParams::is_encrypted(&obj_metadata) {
-            let _ = std::fs::remove_file(&temp_path);
-            return Err(s3err("File is encrypted — password required"));
+            Ok(())
+        }
+        .await;
+
+        if let Err(error) = result {
+            let _ = std::fs::remove_dir_all(&temp_dir);
+            return Err(error);
         }
 
         Ok(temp_path.to_string_lossy().to_string())
@@ -1761,25 +1762,20 @@ impl S3Service {
             .await
             .map_err(|e| s3err(e.to_string()))?;
 
-        let filename = stripped_key.rsplit('/').next().unwrap_or(&stripped_key);
-        let short_vid = if version_id.len() > 8 {
-            &version_id[..8]
-        } else {
-            version_id
-        };
-        let safe_name = format!("{short_vid}-{filename}");
-        let temp_path = std::env::temp_dir().join("furman-preview").join(&safe_name);
-
-        if let Some(parent) = temp_path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
         let body = resp
             .body
             .collect()
             .await
             .map_err(|e| s3err(e.to_string()))?;
-        std::fs::write(&temp_path, body.into_bytes())?;
+        let filename = crate::commands::temp::safe_filename(
+            stripped_key.rsplit('/').next().unwrap_or(&stripped_key),
+        );
+        let temp_dir = crate::commands::temp::create_temp_dir_path("preview")?;
+        let temp_path = temp_dir.join(filename);
+        if let Err(error) = std::fs::write(&temp_path, body.into_bytes()) {
+            let _ = std::fs::remove_dir_all(&temp_dir);
+            return Err(FmError::Io(error));
+        }
 
         Ok(temp_path.to_string_lossy().to_string())
     }

--- a/src-tauri/src/sftp/service.rs
+++ b/src-tauri/src/sftp/service.rs
@@ -657,20 +657,28 @@ impl SftpService {
 
     /// Download a remote file to a temp location, returning the local path.
     pub async fn download_temp(&self, remote_path: &str) -> Result<String, FmError> {
-        let name = remote_path.rsplit('/').next().unwrap_or("file");
-        let tmp_dir = std::env::temp_dir().join("furman-sftp");
-        std::fs::create_dir_all(&tmp_dir).map_err(FmError::Io)?;
+        let name = crate::commands::temp::safe_filename(
+            remote_path.rsplit('/').next().unwrap_or("file"),
+        );
+        let tmp_dir = crate::commands::temp::create_temp_dir_path("preview")?;
         let local_path = tmp_dir.join(name);
 
-        let data = self
+        let data = match self
             .session
             .read(remote_path)
             .await
-            .map_err(|e| sftperr(format!("read '{remote_path}': {e}")))?;
+        {
+            Ok(data) => data,
+            Err(error) => {
+                let _ = std::fs::remove_dir_all(&tmp_dir);
+                return Err(sftperr(format!("read '{remote_path}': {error}")));
+            }
+        };
 
-        tokio::fs::write(&local_path, &data)
-            .await
-            .map_err(FmError::Io)?;
+        if let Err(error) = tokio::fs::write(&local_path, &data).await {
+            let _ = std::fs::remove_dir_all(&tmp_dir);
+            return Err(FmError::Io(error));
+        }
 
         Ok(local_path.to_string_lossy().to_string())
     }

--- a/src/lib/actions/viewers.ts
+++ b/src/lib/actions/viewers.ts
@@ -1,26 +1,33 @@
 import { panels } from '$lib/state/panels.svelte';
 import { appState } from '$lib/state/app.svelte';
 import { statusState } from '$lib/state/status.svelte';
-import { openFileDefault, openInEditor, extractArchiveToTemp } from '$lib/services/tauri';
+import { openFileDefault, openInEditor, extractArchiveToTemp, cleanupTempPath } from '$lib/services/tauri';
 import { s3DownloadToTemp, s3IsObjectEncrypted } from '$lib/services/s3';
 import { sftpDownloadTemp } from '$lib/services/sftp';
 import { error } from '$lib/services/log';
 import { promptEncryptionPassword } from './fileops';
 
 let editorOpenGeneration = 0;
+let viewerOpenGeneration = 0;
 
 function showEditor(
   filePath: string,
   target?:
     | { backend: 's3'; connectionId: string; path: string }
     | { backend: 'sftp'; connectionId: string; path: string },
+  temporary = false,
 ) {
+  const previousTempPath = appState.editorTempPath;
+  if (previousTempPath && previousTempPath !== filePath) {
+    cleanupTempPath(previousTempPath).catch(() => {});
+  }
   appState.editorPath = filePath;
   appState.editorDirty = false;
   appState.editorS3ConnectionId = '';
   appState.editorS3Key = '';
   appState.editorSftpConnectionId = '';
   appState.editorSftpPath = '';
+  appState.editorTempPath = temporary ? filePath : '';
 
   if (target?.backend === 's3') {
     appState.editorS3ConnectionId = target.connectionId;
@@ -31,6 +38,34 @@ function showEditor(
   }
 
   appState.modal = 'editor';
+}
+
+function showViewer(filePath: string, ext: string | null, temporary = false) {
+  const previousTempPath = appState.viewerTempPath;
+  if (previousTempPath && previousTempPath !== filePath) {
+    cleanupTempPath(previousTempPath).catch(() => {});
+  }
+  const lower = (ext ?? '').toLowerCase();
+  appState.viewerMode = imageExtensions.has(lower) ? 'image' : 'text';
+  appState.viewerPath = filePath;
+  appState.viewerTempPath = temporary ? filePath : '';
+  appState.modal = 'viewer';
+}
+
+export function closeViewer() {
+  viewerOpenGeneration++;
+  const tempPath = appState.viewerTempPath;
+  appState.viewerTempPath = '';
+  appState.closeModal();
+  if (tempPath) cleanupTempPath(tempPath).catch(() => {});
+}
+
+export function closeEditor() {
+  editorOpenGeneration++;
+  const tempPath = appState.editorTempPath;
+  appState.editorTempPath = '';
+  appState.closeModal();
+  if (tempPath) cleanupTempPath(tempPath).catch(() => {});
 }
 
 // ── Extension constants ─────────────────────────────────────────────────────
@@ -146,14 +181,13 @@ export async function activateEntry() {
 }
 
 export function openViewer(filePath: string, ext: string | null) {
-  const lower = (ext ?? '').toLowerCase();
-  if (imageExtensions.has(lower)) {
-    appState.viewerMode = 'image';
-  } else {
-    appState.viewerMode = 'text';
-  }
-  appState.viewerPath = filePath;
-  appState.modal = 'viewer';
+  viewerOpenGeneration++;
+  showViewer(filePath, ext);
+}
+
+export function openTemporaryViewer(filePath: string, ext: string | null = null) {
+  viewerOpenGeneration++;
+  showViewer(filePath, ext, true);
 }
 
 export function openEditor(filePath: string) {
@@ -169,41 +203,51 @@ export function openEditor(filePath: string) {
 }
 
 export async function openS3Viewer(s3Path: string, ext: string | null, connectionId: string, password?: string) {
+  const generation = ++viewerOpenGeneration;
   if (!password) {
     try {
       const encrypted = await s3IsObjectEncrypted(connectionId, s3Path);
+      if (generation !== viewerOpenGeneration) return;
       if (encrypted) {
         promptEncryptionPassword((pw) => {
           openS3Viewer(s3Path, ext, connectionId, pw);
         }, 'Decryption password:');
         return;
       }
-    } catch { /* continue without encryption */ }
+    } catch {
+      if (generation !== viewerOpenGeneration) return;
+      // Continue without encryption when metadata detection is unavailable.
+    }
   }
 
   statusState.setMessage('Downloading for preview...');
   try {
     const localPath = await s3DownloadToTemp(connectionId, s3Path, password);
+    if (generation !== viewerOpenGeneration) {
+      cleanupTempPath(localPath).catch(() => {});
+      return;
+    }
     const lower = (ext ?? '').toLowerCase();
     if (systemOpenExtensions.has(lower)) {
-      await openFileDefault(localPath);
+      try {
+        await openFileDefault(localPath);
+      } catch (err) {
+        cleanupTempPath(localPath).catch(() => {});
+        throw err;
+      }
       statusState.setMessage('');
-    } else if (imageExtensions.has(lower)) {
-      appState.viewerMode = 'image';
-      appState.viewerPath = localPath;
-      appState.modal = 'viewer';
     } else {
-      appState.viewerMode = 'text';
-      appState.viewerPath = localPath;
-      appState.modal = 'viewer';
+      showViewer(localPath, ext, true);
     }
   } catch (err: unknown) {
+    if (generation !== viewerOpenGeneration) return;
     error(String(err));
     appState.showAlert('Preview failed: ' + String(err));
   }
 }
 
 export async function openArchiveViewer(entryPath: string, ext: string | null, archivePath: string) {
+  const generation = ++viewerOpenGeneration;
   const hashIdx = entryPath.indexOf('#');
   if (hashIdx < 0) return;
   const internalPath = entryPath.substring(hashIdx + 1);
@@ -211,43 +255,52 @@ export async function openArchiveViewer(entryPath: string, ext: string | null, a
   statusState.setMessage('Extracting for preview...');
   try {
     const localPath = await extractArchiveToTemp(archivePath, internalPath);
+    if (generation !== viewerOpenGeneration) {
+      cleanupTempPath(localPath).catch(() => {});
+      return;
+    }
     const lower = (ext ?? '').toLowerCase();
     if (systemOpenExtensions.has(lower)) {
-      await openFileDefault(localPath);
+      try {
+        await openFileDefault(localPath);
+      } catch (err) {
+        cleanupTempPath(localPath).catch(() => {});
+        throw err;
+      }
       statusState.setMessage('');
-    } else if (imageExtensions.has(lower)) {
-      appState.viewerMode = 'image';
-      appState.viewerPath = localPath;
-      appState.modal = 'viewer';
     } else {
-      appState.viewerMode = 'text';
-      appState.viewerPath = localPath;
-      appState.modal = 'viewer';
+      showViewer(localPath, ext, true);
     }
   } catch (err: unknown) {
+    if (generation !== viewerOpenGeneration) return;
     error(String(err));
     appState.showAlert('Preview failed: ' + String(err));
   }
 }
 
 export async function openSftpViewer(sftpPath: string, ext: string | null, connectionId: string) {
+  const generation = ++viewerOpenGeneration;
   statusState.setMessage('Downloading for preview...');
   try {
     const localPath = await sftpDownloadTemp(connectionId, sftpPath);
+    if (generation !== viewerOpenGeneration) {
+      cleanupTempPath(localPath).catch(() => {});
+      return;
+    }
     const lower = (ext ?? '').toLowerCase();
     if (systemOpenExtensions.has(lower)) {
-      await openFileDefault(localPath);
+      try {
+        await openFileDefault(localPath);
+      } catch (err) {
+        cleanupTempPath(localPath).catch(() => {});
+        throw err;
+      }
       statusState.setMessage('');
-    } else if (imageExtensions.has(lower)) {
-      appState.viewerMode = 'image';
-      appState.viewerPath = localPath;
-      appState.modal = 'viewer';
     } else {
-      appState.viewerMode = 'text';
-      appState.viewerPath = localPath;
-      appState.modal = 'viewer';
+      showViewer(localPath, ext, true);
     }
   } catch (err: unknown) {
+    if (generation !== viewerOpenGeneration) return;
     error(String(err));
     appState.showAlert('Preview failed: ' + String(err));
   }
@@ -274,8 +327,11 @@ export async function openS3Editor(s3Path: string, connectionId: string, passwor
   statusState.setMessage('Downloading for editing...');
   try {
     const localPath = await s3DownloadToTemp(connectionId, s3Path, password);
-    if (generation !== editorOpenGeneration) return;
-    showEditor(localPath, { backend: 's3', connectionId, path: s3Path });
+    if (generation !== editorOpenGeneration) {
+      cleanupTempPath(localPath).catch(() => {});
+      return;
+    }
+    showEditor(localPath, { backend: 's3', connectionId, path: s3Path }, true);
   } catch (err: unknown) {
     if (generation !== editorOpenGeneration) return;
     error(String(err));
@@ -288,8 +344,11 @@ export async function openSftpEditor(sftpPath: string, connectionId: string) {
   statusState.setMessage('Downloading for editing...');
   try {
     const localPath = await sftpDownloadTemp(connectionId, sftpPath);
-    if (generation !== editorOpenGeneration) return;
-    showEditor(localPath, { backend: 'sftp', connectionId, path: sftpPath });
+    if (generation !== editorOpenGeneration) {
+      cleanupTempPath(localPath).catch(() => {});
+      return;
+    }
+    showEditor(localPath, { backend: 'sftp', connectionId, path: sftpPath }, true);
   } catch (err: unknown) {
     if (generation !== editorOpenGeneration) return;
     error(String(err));

--- a/src/lib/components/ComparisonBar.svelte
+++ b/src/lib/components/ComparisonBar.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
   import { comparisonState, type ComparisonFilter } from '$lib/state/comparison.svelte';
 
+  interface Props {
+    side: 'left' | 'right';
+  }
+
+  let { side }: Props = $props();
+  const counts = $derived(comparisonState.countsFor(side));
+
   const filters: { id: ComparisonFilter; label: string; color: string }[] = [
     { id: 'all', label: 'All', color: 'var(--text-secondary)' },
     { id: 'new', label: 'Only here', color: 'var(--git-added)' },
@@ -14,15 +21,15 @@
     <span class="spinner"></span>
     <span class="bar-label">Comparing...</span>
   {:else}
-    <span class="badge green">{comparisonState.counts.new}</span>
-    <span class="badge yellow">{comparisonState.counts.modified}</span>
-    <span class="badge red">{comparisonState.counts.deleted}</span>
+    <span class="badge green">{counts.new}</span>
+    <span class="badge yellow">{counts.modified}</span>
+    <span class="badge red">{counts.deleted}</span>
     {#each filters as f (f.id)}
       <button
         class="filter-btn"
-        class:active={comparisonState.filter === f.id}
+        class:active={comparisonState.filterFor(side) === f.id}
         style="--filter-color: {f.color}"
-        onclick={() => comparisonState.setFilter(f.id)}
+        onclick={() => comparisonState.setFilter(f.id, side)}
       >{f.label}</button>
     {/each}
   {/if}

--- a/src/lib/components/DualPanel.svelte
+++ b/src/lib/components/DualPanel.svelte
@@ -51,6 +51,9 @@
               onAdd={() => { const path = panels.left.path; const tab = panels.addTab('left'); tab.loadDirectory(path); }}
             />
           {/if}
+          {#if comparisonState.active}
+            <ComparisonBar side="left" />
+          {/if}
           <FilePanel
             panel={panels.left}
             isActive={true}
@@ -77,6 +80,9 @@
               onClose={(i) => panels.closeTab('right', i)}
               onAdd={() => { const path = panels.right.path; const tab = panels.addTab('right'); tab.loadDirectory(path); }}
             />
+          {/if}
+          {#if comparisonState.active}
+            <ComparisonBar side="right" />
           {/if}
           <FilePanel
             panel={panels.right}
@@ -139,7 +145,7 @@
           />
         {/if}
         {#if comparisonState.active}
-          <ComparisonBar />
+          <ComparisonBar side="left" />
         {/if}
         <FilePanel
           panel={panels.left}
@@ -189,7 +195,7 @@
           />
         {/if}
         {#if comparisonState.active}
-          <ComparisonBar />
+          <ComparisonBar side="right" />
         {/if}
         <FilePanel
           panel={panels.right}

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -22,6 +22,7 @@
 	let loading = $state(true);
 	let error = $state<string | null>(null);
 	let saving = $state(false);
+	let showDiscardConfirm = $state(false);
 	let editorContainer: HTMLDivElement | undefined = $state(undefined);
 	let view: EditorView | undefined = $state(undefined);
 
@@ -135,6 +136,14 @@
 	}
 
 	function handleKeydown(e: KeyboardEvent) {
+		if (showDiscardConfirm) {
+			if (e.key === 'Escape') {
+				e.preventDefault();
+				e.stopPropagation();
+				showDiscardConfirm = false;
+			}
+			return;
+		}
 		if (e.key === 'Escape' || ((e.ctrlKey || e.metaKey) && e.key === 'w')) {
 			e.preventDefault();
 			e.stopPropagation();
@@ -159,10 +168,7 @@
 
 	function handleClose() {
 		if (dirty) {
-			appState.showConfirm('File has been modified. Discard changes?', () => {
-				appState.closeModal();
-				onClose();
-			});
+			showDiscardConfirm = true;
 		} else {
 			onClose();
 		}
@@ -199,6 +205,18 @@
 
 	{#if error && content}
 		<div class="editor-status-error">Error: {error}</div>
+	{/if}
+
+	{#if showDiscardConfirm}
+		<div class="discard-overlay" role="alertdialog" aria-modal="true" aria-label="Discard changes">
+			<div class="discard-dialog">
+				<div>File has been modified. Discard changes?</div>
+				<div class="discard-actions">
+					<button onclick={() => { showDiscardConfirm = false; onClose(); }}>Discard</button>
+					<button class="primary" onclick={() => { showDiscardConfirm = false; view?.focus(); }}>Keep editing</button>
+				</div>
+			</div>
+		</div>
 	{/if}
 </div>
 
@@ -266,5 +284,42 @@
 		flex: 0 0 auto;
 		font-size: 12px;
 		border-top: 1px solid var(--border-subtle);
+	}
+
+	.discard-overlay {
+		position: absolute;
+		inset: 0;
+		display: grid;
+		place-items: center;
+		background: color-mix(in srgb, var(--bg-primary) 70%, transparent);
+		z-index: 1;
+	}
+
+	.discard-dialog {
+		min-width: 320px;
+		padding: 18px;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border-active);
+		border-radius: var(--radius-md);
+		box-shadow: var(--shadow-dialog);
+	}
+
+	.discard-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 8px;
+		margin-top: 16px;
+	}
+
+	.discard-actions button {
+		padding: 5px 12px;
+		border: 1px solid var(--border-subtle);
+		border-radius: var(--radius-sm);
+		background: var(--bg-tertiary);
+		color: var(--text-primary);
+	}
+
+	.discard-actions button.primary {
+		border-color: var(--text-accent);
 	}
 </style>

--- a/src/lib/components/FilePanel.svelte
+++ b/src/lib/components/FilePanel.svelte
@@ -19,7 +19,7 @@
   interface Props {
     panel: PanelData;
     isActive: boolean;
-    side?: 'left' | 'right';
+    side: 'left' | 'right';
     onActivate?: () => void;
     onEntryActivate?: (index: number) => void;
     onDrop?: (sourceSide: 'left' | 'right', shiftKey: boolean) => void;
@@ -162,10 +162,35 @@
   });
 
   // Clamp cursor when filtered list length changes
+  let previousComparisonFilter = comparisonState.active && comparisonState.filter !== 'all'
+    ? ''
+    : `${comparisonState.filterSide}:${comparisonState.filter}`;
   $effect(() => {
+    const comparisonFilter = `${comparisonState.filterSide}:${comparisonState.filter}`;
+    if (comparisonFilter !== previousComparisonFilter) {
+      previousComparisonFilter = comparisonFilter;
+      panel.cursorIndex = 0;
+      panel.selectionAnchor = 0;
+    }
     const len = panel.filteredSortedEntries.length;
-    if (len > 0 && panel.cursorIndex >= len) {
-      panel.cursorIndex = len - 1;
+    const max = Math.max(0, len - 1);
+    if (panel.cursorIndex < 0 || panel.cursorIndex > max) {
+      panel.cursorIndex = max;
+    }
+    if (panel.selectionAnchor < 0 || panel.selectionAnchor > max) {
+      panel.selectionAnchor = max;
+    }
+    if (comparisonState.active && comparisonState.filterFor(side) !== 'all') {
+      const visiblePaths = new Set(
+        panel.entries
+          .filter((entry) => entry.name !== '..')
+          .filter((entry) => comparisonState.matchesFilter(side, panel.path, entry))
+          .map((entry) => entry.path),
+      );
+      const visibleSelection = [...panel.selectedPaths].filter((path) => visiblePaths.has(path));
+      if (visibleSelection.length !== panel.selectedPaths.size) {
+        panel.selectedPaths = new SvelteSet(visibleSelection);
+      }
     }
   });
 
@@ -186,36 +211,13 @@
     }
   });
 
-  // Comparison: derive a map from entry name → ComparisonStatus for this panel
-  // Pre-builds dirty-directory sets from statusMap (O(M)), then each entry lookup is O(1).
+  // Comparison: derive a map from entry name → ComparisonStatus for this panel.
   const comparisonStatusMap = $derived.by((): Map<string, ComparisonStatus> => {
     if (!comparisonState.active) return new SvelteMap();
-    const statusMap = side === 'right' ? comparisonState.rightStatuses : comparisonState.leftStatuses;
-
-    // Pre-build sets of top-level directories that have modified/changed children
-    const dirModified = new SvelteSet<string>();
-    const dirChanged = new SvelteSet<string>();
-    for (const [key, val] of statusMap) {
-      if (val === 'same') continue;
-      const slashIdx = key.indexOf('/');
-      if (slashIdx > 0) {
-        const topDir = key.substring(0, slashIdx);
-        if (val === 'modified') dirModified.add(topDir);
-        else dirChanged.add(topDir);
-      }
-    }
-
     const result = new SvelteMap<string, ComparisonStatus>();
     for (const entry of panel.filteredSortedEntries) {
-      if (entry.name === '..') continue;
-      const status = statusMap.get(entry.name);
-      if (status) {
-        result.set(entry.name, status);
-      } else if (entry.is_dir) {
-        if (dirModified.has(entry.name) || dirChanged.has(entry.name)) {
-          result.set(entry.name, 'modified');
-        }
-      }
+      const status = comparisonState.statusForEntry(side, panel.path, entry);
+      if (status) result.set(entry.name, status);
     }
     return result;
   });

--- a/src/lib/components/PropertiesDialog.svelte
+++ b/src/lib/components/PropertiesDialog.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import { onMount, untrack } from 'svelte';
+  import { onDestroy, onMount, untrack } from 'svelte';
   import { appState } from '$lib/state/app.svelte';
-  import { getFileProperties, getDirectorySize, inspectModel } from '$lib/services/tauri';
+  import { cleanupTempPath, getFileProperties, getDirectorySize, inspectModel } from '$lib/services/tauri';
+  import { openTemporaryViewer } from '$lib/actions/viewers';
   import { formatParams, formatVram, estimateVram, groupTensorsByCategory, groupTensorsByLayer, getCategoryColor, type VramEstimate } from '$lib/utils/model';
   import MfaDialog from './MfaDialog.svelte';
   import CloudFrontTab from './CloudFrontTab.svelte';
@@ -227,6 +228,11 @@
   let versionsLoading = $state(false);
   let versionsError = $state('');
   let versionActionLoading = $state<string | null>(null);
+  let versionDownloadGeneration = 0;
+
+  onDestroy(() => {
+    versionDownloadGeneration++;
+  });
 
   // Bucket-level: Versioning
   let bucketVersioning = $state<S3BucketVersioning | null>(null);
@@ -462,17 +468,19 @@
   }
 
   async function handleDownloadVersion(vid: string) {
+    const generation = ++versionDownloadGeneration;
     versionActionLoading = vid;
     try {
       const tempPath = await s3DownloadVersion(s3ConnectionId, path, vid);
-      const { appState: app } = await import('$lib/state/app.svelte');
-      app.viewerMode = 'text';
-      app.viewerPath = tempPath;
-      app.modal = 'viewer';
+      if (generation !== versionDownloadGeneration) {
+        cleanupTempPath(tempPath).catch(() => {});
+        return;
+      }
+      openTemporaryViewer(tempPath);
     } catch (err: unknown) {
-      versionsError = String(err);
+      if (generation === versionDownloadGeneration) versionsError = String(err);
     } finally {
-      versionActionLoading = null;
+      if (generation === versionDownloadGeneration) versionActionLoading = null;
     }
   }
 

--- a/src/lib/services/drag.ts
+++ b/src/lib/services/drag.ts
@@ -1,6 +1,7 @@
 import { startDrag } from '@crabnebula/tauri-plugin-drag';
 import { s3DownloadToTemp } from './s3';
 import { sftpDownloadTemp } from './sftp';
+import { cleanupTempPath } from './tauri';
 
 export interface DragSource {
   side: 'left' | 'right';
@@ -79,23 +80,46 @@ export async function startLocalFileDrag(paths: string[], mode: 'copy' | 'move' 
 }
 
 export async function startS3FileDrag(connectionId: string, keys: string[], mode: 'copy' | 'move' = 'copy'): Promise<void> {
-  const tempPaths = await Promise.all(
-    keys.map((key) => s3DownloadToTemp(connectionId, key)),
-  );
-  await startDrag({ item: tempPaths, icon: makeDragIcon(tempPaths.length), mode }, (payload) => {
-    if (payload.result === 'Dropped') {
-      emitInternalDrop(Number(payload.cursorPos.x), Number(payload.cursorPos.y));
-    }
-  });
+  await startRemoteFileDrag(keys, (key) => s3DownloadToTemp(connectionId, key), mode);
 }
 
 export async function startSftpFileDrag(connectionId: string, paths: string[], mode: 'copy' | 'move' = 'copy'): Promise<void> {
-  const tempPaths = await Promise.all(
-    paths.map((p) => sftpDownloadTemp(connectionId, p)),
-  );
-  await startDrag({ item: tempPaths, icon: makeDragIcon(tempPaths.length), mode }, (payload) => {
-    if (payload.result === 'Dropped') {
-      emitInternalDrop(Number(payload.cursorPos.x), Number(payload.cursorPos.y));
+  await startRemoteFileDrag(paths, (path) => sftpDownloadTemp(connectionId, path), mode);
+}
+
+async function startRemoteFileDrag(
+  sources: string[],
+  download: (source: string) => Promise<string>,
+  mode: 'copy' | 'move',
+) {
+  const results = await Promise.allSettled(sources.map(download));
+  const tempPaths = results
+    .filter((result): result is PromiseFulfilledResult<string> => result.status === 'fulfilled')
+    .map((result) => result.value);
+  const failed = results.find((result): result is PromiseRejectedResult => result.status === 'rejected');
+
+  if (failed) {
+    await Promise.allSettled(tempPaths.map(cleanupTempPath));
+    throw failed.reason;
+  }
+
+  let dropped = false;
+  try {
+    await new Promise<void>((resolve, reject) => {
+      startDrag({ item: tempPaths, icon: makeDragIcon(tempPaths.length), mode }, (payload) => {
+        if (payload.result === 'Dropped') {
+          dropped = true;
+          emitInternalDrop(Number(payload.cursorPos.x), Number(payload.cursorPos.y));
+        }
+        resolve();
+      }).catch(reject);
+    });
+  } finally {
+    if (dropped) {
+      // External drop targets may continue reading after accepting the paths.
+      setTimeout(() => void Promise.allSettled(tempPaths.map(cleanupTempPath)), 30 * 60 * 1000);
+    } else {
+      await Promise.allSettled(tempPaths.map(cleanupTempPath));
     }
-  });
+  }
 }

--- a/src/lib/services/tauri.ts
+++ b/src/lib/services/tauri.ts
@@ -48,6 +48,14 @@ export async function createDirectory(path: string): Promise<void> {
   await invoke('create_directory', { path });
 }
 
+export async function createTempDir(category: string): Promise<string> {
+  return await invoke<string>('create_temp_dir', { category });
+}
+
+export async function cleanupTempPath(path: string): Promise<void> {
+  await invoke('cleanup_temp_path', { path });
+}
+
 export async function copyFiles(
   id: string,
   sources: string[],

--- a/src/lib/state/app.svelte.ts
+++ b/src/lib/state/app.svelte.ts
@@ -24,6 +24,7 @@ class AppState {
   viewerPath = $state('');
   viewerMode = $state<ViewerMode>('text');
   viewerContent = $state('');
+  viewerTempPath = $state('');
   editorPath = $state('');
   editorContent = $state('');
   editorDirty = $state(false);
@@ -31,6 +32,7 @@ class AppState {
   editorS3Key = $state('');
   editorSftpConnectionId = $state('');
   editorSftpPath = $state('');
+  editorTempPath = $state('');
   confirmMessage = $state('');
   confirmCallback = $state<(() => void) | null>(null);
   confirmAlertOnly = $state(false);

--- a/src/lib/state/comparison.svelte.ts
+++ b/src/lib/state/comparison.svelte.ts
@@ -1,18 +1,25 @@
 import { syncDiff, cancelSync } from '$lib/services/tauri';
-import type { SyncEvent, SyncEntry, PanelBackend } from '$lib/types';
+import type { SyncEvent, SyncEntry, PanelBackend, FileEntry } from '$lib/types';
 import { statusState } from '$lib/state/status.svelte';
 import { appState } from '$lib/state/app.svelte';
+import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 
 export type ComparisonStatus = 'new' | 'modified' | 'deleted' | 'same';
 export type ComparisonFilter = 'all' | 'new' | 'modified' | 'deleted';
+export type ComparisonSide = 'left' | 'right';
 
 class ComparisonState {
   active = $state(false);
   scanning = $state(false);
   filter = $state<ComparisonFilter>('all');
-  leftStatuses: Map<string, ComparisonStatus> = $state(new Map());
-  rightStatuses: Map<string, ComparisonStatus> = $state(new Map());
+  filterSide = $state<ComparisonSide>('left');
+  leftStatuses: Map<string, ComparisonStatus> = $state(new SvelteMap());
+  rightStatuses: Map<string, ComparisonStatus> = $state(new SvelteMap());
   counts = $state({ new: 0, modified: 0, deleted: 0 });
+  private leftRoot = '';
+  private rightRoot = '';
+  private leftDirectoryStatuses = new SvelteMap<string, Set<ComparisonStatus>>();
+  private rightDirectoryStatuses = new SvelteMap<string, Set<ComparisonStatus>>();
   private syncId = '';
   private flushTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -24,8 +31,10 @@ class ComparisonState {
 
   private flushNow() {
     if (this.flushTimer) { clearTimeout(this.flushTimer); this.flushTimer = null; }
-    this.leftStatuses = new Map(this.leftStatuses);
-    this.rightStatuses = new Map(this.rightStatuses);
+    this.leftStatuses = new SvelteMap(this.leftStatuses);
+    this.rightStatuses = new SvelteMap(this.rightStatuses);
+    this.leftDirectoryStatuses = this.buildDirectoryStatuses(this.leftStatuses);
+    this.rightDirectoryStatuses = this.buildDirectoryStatuses(this.rightStatuses);
   }
 
   async startComparison(
@@ -47,15 +56,19 @@ class ComparisonState {
     this.active = true;
     this.scanning = true;
     this.filter = 'all';
-    this.leftStatuses = new Map();
-    this.rightStatuses = new Map();
+    this.filterSide = 'left';
+    this.leftStatuses = new SvelteMap();
+    this.rightStatuses = new SvelteMap();
     this.counts = { new: 0, modified: 0, deleted: 0 };
+    this.leftRoot = this.normalizePath(leftPath);
+    this.rightRoot = this.normalizePath(rightPath);
 
-    this.syncId = 'cmp-' + Date.now() + '-' + Math.random().toString(36).slice(2, 6);
+    const syncId = 'cmp-' + Date.now() + '-' + Math.random().toString(36).slice(2, 6);
+    this.syncId = syncId;
 
     try {
       await syncDiff(
-        this.syncId,
+        syncId,
         leftBackend,
         leftPath,
         leftS3Id,
@@ -65,6 +78,7 @@ class ComparisonState {
         ['.DS_Store', 'Thumbs.db'],
         'size-and-date',
         (event: SyncEvent) => {
+          if (this.syncId !== syncId) return;
           if (event.type === 'Entry') {
             const entry = event as SyncEvent & { type: 'Entry' } & SyncEntry;
             const relPath = entry.relative_path;
@@ -95,15 +109,18 @@ class ComparisonState {
               deleted: event.deleted ?? 0,
             };
             this.scanning = false;
+            this.syncId = '';
           }
         },
       );
     } catch (err: unknown) {
+      if (this.syncId !== syncId) return;
       const msg = String(err);
       if (!msg.includes('cancelled')) {
         appState.showAlert('Comparison failed: ' + msg);
       }
       this.scanning = false;
+      this.syncId = '';
     }
   }
 
@@ -114,14 +131,103 @@ class ComparisonState {
     }
     this.active = false;
     this.scanning = false;
-    this.leftStatuses = new Map();
-    this.rightStatuses = new Map();
+    this.leftStatuses = new SvelteMap();
+    this.rightStatuses = new SvelteMap();
+    this.leftDirectoryStatuses = new SvelteMap();
+    this.rightDirectoryStatuses = new SvelteMap();
+    this.leftRoot = '';
+    this.rightRoot = '';
     this.counts = { new: 0, modified: 0, deleted: 0 };
     this.filter = 'all';
   }
 
-  setFilter(f: ComparisonFilter) {
+  setFilter(f: ComparisonFilter, side: ComparisonSide) {
     this.filter = f;
+    this.filterSide = side;
+  }
+
+  filterFor(side: ComparisonSide): ComparisonFilter {
+    if (this.filter === 'all' || side === this.filterSide || this.filter === 'modified') {
+      return this.filter;
+    }
+    return this.filter === 'new' ? 'deleted' : 'new';
+  }
+
+  containsPanelPath(side: ComparisonSide, panelPath: string): boolean {
+    return this.entryRelativePath(side, panelPath, '') !== null;
+  }
+
+  statusForEntry(side: ComparisonSide, panelPath: string, entry: FileEntry): ComparisonStatus | undefined {
+    if (!this.active || entry.name === '..') return undefined;
+    const relativePath = this.entryRelativePath(side, panelPath, entry.name);
+    if (relativePath === null) return undefined;
+    const statuses = side === 'left' ? this.leftStatuses : this.rightStatuses;
+    const direct = statuses.get(relativePath);
+    if (direct) return direct;
+    if (entry.is_dir) {
+      const directoryStatuses = side === 'left'
+        ? this.leftDirectoryStatuses
+        : this.rightDirectoryStatuses;
+      if (directoryStatuses.has(relativePath)) return 'modified';
+    }
+    return undefined;
+  }
+
+  matchesFilter(side: ComparisonSide, panelPath: string, entry: FileEntry): boolean {
+    const filter = this.filterFor(side);
+    if (!this.active || filter === 'all' || entry.name === '..') return true;
+    const relativePath = this.entryRelativePath(side, panelPath, entry.name);
+    if (relativePath === null) return false;
+    const statuses = side === 'left' ? this.leftStatuses : this.rightStatuses;
+    if (statuses.get(relativePath) === filter) return true;
+    if (!entry.is_dir) return false;
+    const directoryStatuses = side === 'left'
+      ? this.leftDirectoryStatuses
+      : this.rightDirectoryStatuses;
+    return directoryStatuses.get(relativePath)?.has(filter) ?? false;
+  }
+
+  countsFor(side: ComparisonSide) {
+    if (side === 'left') return this.counts;
+    return {
+      new: this.counts.deleted,
+      modified: this.counts.modified,
+      deleted: this.counts.new,
+    };
+  }
+
+  private buildDirectoryStatuses(statuses: Map<string, ComparisonStatus>) {
+    const result = new SvelteMap<string, Set<ComparisonStatus>>();
+    for (const [path, status] of statuses) {
+      if (status === 'same') continue;
+      const parts = path.split('/').filter(Boolean);
+      for (let i = 1; i < parts.length; i++) {
+        const directory = parts.slice(0, i).join('/');
+        const values = result.get(directory) ?? new SvelteSet<ComparisonStatus>();
+        values.add(status);
+        result.set(directory, values);
+      }
+    }
+    return result;
+  }
+
+  private entryRelativePath(side: ComparisonSide, panelPath: string, entryName: string): string | null {
+    const root = side === 'left' ? this.leftRoot : this.rightRoot;
+    const current = this.normalizePath(panelPath);
+    if (!root) return null;
+    let prefix: string;
+    if (root === '/') {
+      if (!current.startsWith('/')) return null;
+      prefix = current === '/' ? '' : current.slice(1);
+    } else {
+      if (current !== root && !current.startsWith(root + '/')) return null;
+      prefix = current === root ? '' : current.slice(root.length + 1);
+    }
+    return prefix ? `${prefix}/${entryName}` : entryName;
+  }
+
+  private normalizePath(path: string) {
+    return path.length > 1 ? path.replace(/\/+$/, '') : path;
   }
 }
 

--- a/src/lib/state/panels.svelte.ts
+++ b/src/lib/state/panels.svelte.ts
@@ -1,11 +1,12 @@
 import type { FileEntry, SortField, SortDirection, ViewMode, PanelBackend, S3ConnectionInfo, SftpConnectionInfo, ArchiveInfo, GitRepoInfo, DirListEvent } from '$lib/types';
 import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 import { sortEntries } from '$lib/utils/sort';
-import { listDirectory, listDirectoryStreamed, listArchive, watchDirectory, unwatchDirectory, getGitRepoInfo, getDirectorySize } from '$lib/services/tauri';
+import { listDirectory, listDirectoryStreamed, listArchive, watchDirectory, unwatchDirectory, getGitRepoInfo, getDirectorySize, cleanupTempPath } from '$lib/services/tauri';
 import { s3Connect, s3Disconnect, s3ListObjects, s3IsObjectEncrypted } from '$lib/services/s3';
 import { sftpConnect, sftpDisconnect, sftpListObjects } from '$lib/services/sftp';
 import { mountNetworkShare } from '$lib/services/mount';
 import { appState } from '$lib/state/app.svelte';
+import { comparisonState, type ComparisonSide } from '$lib/state/comparison.svelte';
 
 /// Threshold above which we use streamed directory listing.
 const STREAM_THRESHOLD = 50_000;
@@ -20,6 +21,7 @@ export class PanelData {
   entries = $state<FileEntry[]>([]);
   watchId: string;
   tabId: number;
+  side: ComparisonSide;
   cursorIndex = $state(0);
   selectionAnchor = $state(0);
   selectedPaths = $state<Set<string>>(new SvelteSet());
@@ -60,23 +62,28 @@ export class PanelData {
   private cachedGlobRegex: RegExp | null = null;
 
   filteredSortedEntries = $derived.by(() => {
-    if (!this.filterText) return this.sortedEntries;
-    const pattern = this.filterText;
-    const hasGlob = pattern.includes('*') || pattern.includes('?');
-    if (hasGlob) {
-      if (pattern !== this.cachedGlobPattern) {
-        this.cachedGlobPattern = pattern;
-        this.cachedGlobRegex = globToRegex(pattern);
+    let result = this.sortedEntries;
+    if (this.filterText) {
+      const pattern = this.filterText;
+      const hasGlob = pattern.includes('*') || pattern.includes('?');
+      if (hasGlob) {
+        if (pattern !== this.cachedGlobPattern) {
+          this.cachedGlobPattern = pattern;
+          this.cachedGlobRegex = globToRegex(pattern);
+        }
+        const re = this.cachedGlobRegex!;
+        result = result.filter((e) => e.name === '..' || re.test(e.name));
+      } else {
+        const lower = pattern.toLowerCase();
+        result = result.filter(
+          (e) => e.name === '..' || e.name.toLowerCase().includes(lower)
+        );
       }
-      const re = this.cachedGlobRegex!;
-      return this.sortedEntries.filter(
-        (e) => e.name === '..' || re.test(e.name)
-      );
     }
-    const lower = pattern.toLowerCase();
-    return this.sortedEntries.filter(
-      (e) => e.name === '..' || e.name.toLowerCase().includes(lower)
-    );
+    if (comparisonState.active && comparisonState.filterFor(this.side) !== 'all') {
+      result = result.filter((entry) => comparisonState.matchesFilter(this.side, this.path, entry));
+    }
+    return result;
   });
 
   currentEntry = $derived(this.filteredSortedEntries[this.cursorIndex] ?? null);
@@ -113,7 +120,8 @@ export class PanelData {
   private encryptionPending = new SvelteSet<string>();
   private encryptionDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
-  constructor(side: string) {
+  constructor(side: ComparisonSide) {
+    this.side = side;
     this.tabId = nextTabId++;
     this.watchId = `watch-${side}-${this.tabId}`;
   }
@@ -196,6 +204,7 @@ export class PanelData {
     try {
       const listing = await listDirectory(this.path, appState.showHidden);
       if (entriesEqual(this.entries, listing.entries)) return;
+      if (comparisonState.active) comparisonState.stopComparison();
       this.freeSpace = listing.free_space;
       // Preserve cursor by name across entry changes
       const cursorName = this.filteredSortedEntries[this.cursorIndex]?.name;
@@ -246,6 +255,12 @@ export class PanelData {
       return;
     }
 
+    if (comparisonState.active) {
+      if (path === this.path || !comparisonState.containsPanelPath(this.side, path)) {
+        comparisonState.stopComparison();
+      }
+    }
+
     this.loading = true;
     this.error = null;
     try {
@@ -274,12 +289,12 @@ export class PanelData {
       this.gitInfo = null;
       // Position cursor on focusName if provided (e.g. directory we just left)
       if (focusName) {
-        const sorted = sortEntries(this.entries, this.sortField, this.sortDirection);
-        const idx = sorted.findIndex((e) => e.name === focusName);
+        const idx = this.filteredSortedEntries.findIndex((e) => e.name === focusName);
         this.cursorIndex = idx >= 0 ? idx : 0;
       } else {
         this.cursorIndex = 0;
       }
+      this.selectionAnchor = this.cursorIndex;
     } catch (err: unknown) {
       this.error = err instanceof Error ? err.message : String(err);
     } finally {
@@ -300,6 +315,7 @@ export class PanelData {
     this.entries = [];
     this.selectedPaths = new SvelteSet();
     this.cursorIndex = 0;
+    this.selectionAnchor = 0;
 
     try {
       await listDirectoryStreamed(path, appState.showHidden, (event: DirListEvent) => {
@@ -331,12 +347,12 @@ export class PanelData {
 
           // Position cursor on focusName if provided
           if (focusName) {
-            const sorted = sortEntries(this.entries, this.sortField, this.sortDirection);
-            const idx = sorted.findIndex((e) => e.name === focusName);
+            const idx = this.filteredSortedEntries.findIndex((e) => e.name === focusName);
             this.cursorIndex = idx >= 0 ? idx : 0;
           } else {
             this.cursorIndex = 0;
           }
+          this.selectionAnchor = this.cursorIndex;
 
           // Fetch git info non-blocking
           getGitRepoInfo(event.path).then((info) => {
@@ -385,19 +401,28 @@ export class PanelData {
   }
 
   async enterArchive(archivePath: string, remoteOrigin?: ArchiveInfo['remoteOrigin']) {
+    if (comparisonState.active) comparisonState.stopComparison();
+    this.releaseTemporaryArchive();
     this.clearHistory();
     this.backend = 'archive';
-    this.archiveInfo = { archivePath, internalPath: '', remoteOrigin };
+    this.archiveInfo = {
+      archivePath,
+      internalPath: '',
+      remoteOrigin,
+      temporaryPath: remoteOrigin ? archivePath : undefined,
+    };
     await this.loadDirectory(`archive://${archivePath}#`);
   }
 
   private async exitArchive(realPath: string, focusName?: string) {
     this.clearHistory();
     const origin = this.archiveInfo?.remoteOrigin;
+    const temporaryPath = this.archiveInfo?.temporaryPath;
     const archiveName = this.archiveInfo
       ? this.archiveInfo.archivePath.replace(/\/+$/, '').split('/').pop() ?? ''
       : '';
     this.archiveInfo = null;
+    if (temporaryPath) cleanupTempPath(temporaryPath).catch(() => {});
 
     if (origin) {
       // Restore remote backend connection
@@ -411,12 +436,20 @@ export class PanelData {
     }
   }
 
+  private releaseTemporaryArchive() {
+    const temporaryPath = this.archiveInfo?.temporaryPath;
+    this.archiveInfo = null;
+    if (temporaryPath) cleanupTempPath(temporaryPath).catch(() => {});
+  }
+
   async connectS3(info: S3ConnectionInfo, endpoint?: string, profile?: string, accessKey?: string, secretKey?: string, roleArn?: string, externalId?: string, sessionName?: string, sessionDurationSecs?: number, useTransferAcceleration?: boolean, anonymous?: boolean, webIdentityToken?: string, proxyUrl?: string, proxyUsername?: string, proxyPassword?: string) {
+    if (comparisonState.active) comparisonState.stopComparison();
     this.clearHistory();
     this.loading = true;
     this.error = null;
     try {
       await s3Connect(info.connectionId, info.bucket, info.region, endpoint, profile, accessKey, secretKey, roleArn, externalId, sessionName, sessionDurationSecs, useTransferAcceleration, anonymous, webIdentityToken, proxyUrl, proxyUsername, proxyPassword);
+      this.releaseTemporaryArchive();
       this.backend = 's3';
       this.s3Connection = info;
       // Load root of the bucket
@@ -428,6 +461,8 @@ export class PanelData {
   }
 
   async disconnectS3(homePath?: string) {
+    if (comparisonState.active) comparisonState.stopComparison();
+    this.releaseTemporaryArchive();
     this.clearHistory();
     if (this.s3Connection) {
       try {
@@ -443,11 +478,13 @@ export class PanelData {
   }
 
   async connectSftp(info: SftpConnectionInfo, password?: string, keyPath?: string, keyPassphrase?: string, agentSocket?: string) {
+    if (comparisonState.active) comparisonState.stopComparison();
     this.clearHistory();
     this.loading = true;
     this.error = null;
     try {
       const homeDir = await sftpConnect(info.connectionId, info.host, info.port, info.username, password ? 'password' : keyPath ? 'key' : 'agent', password, keyPath, keyPassphrase, agentSocket, appState.sftpInactivityTimeout, appState.sftpKeepaliveInterval, appState.sftpOperationTimeout);
+      this.releaseTemporaryArchive();
       this.backend = 'sftp';
       this.sftpConnection = info;
       await this.loadDirectory(`sftp://${info.host}:${info.port}${homeDir.startsWith('/') ? '' : '/'}${homeDir}/`);
@@ -460,10 +497,12 @@ export class PanelData {
   /// Mount an SMB/NFS share through the OS and navigate this panel to it as a
   /// local folder. Throws on failure so the caller can surface the error.
   async mountShare(protocol: 'smb' | 'nfs', host: string, share: string, username?: string, password?: string, domain?: string) {
+    if (comparisonState.active) comparisonState.stopComparison();
     this.loading = true;
     this.error = null;
     try {
       const mountPoint = await mountNetworkShare(protocol, host, share, username, password, domain);
+      this.releaseTemporaryArchive();
       this.clearHistory();
       this.backend = 'local';
       await this.loadDirectory(mountPoint);
@@ -474,6 +513,8 @@ export class PanelData {
   }
 
   async disconnectSftp(homePath?: string) {
+    if (comparisonState.active) comparisonState.stopComparison();
+    this.releaseTemporaryArchive();
     this.clearHistory();
     if (this.sftpConnection) {
       try {
@@ -517,7 +558,7 @@ export class PanelData {
 
   selectAll() {
     const next = new SvelteSet<string>();
-    for (const entry of this.entries) {
+    for (const entry of this.filteredSortedEntries) {
       if (entry.name !== '..') {
         next.add(entry.path);
       }
@@ -531,7 +572,7 @@ export class PanelData {
 
   invertSelection() {
     const next = new SvelteSet<string>();
-    for (const entry of this.entries) {
+    for (const entry of this.filteredSortedEntries) {
       if (entry.name !== '..' && !this.selectedPaths.has(entry.path)) {
         next.add(entry.path);
       }
@@ -542,7 +583,7 @@ export class PanelData {
   selectByPattern(pattern: string) {
     const re = globToRegex(pattern);
     const next = new SvelteSet(this.selectedPaths);
-    for (const entry of this.entries) {
+    for (const entry of this.filteredSortedEntries) {
       if (entry.name !== '..' && re.test(entry.name)) {
         next.add(entry.path);
       }
@@ -553,7 +594,7 @@ export class PanelData {
   deselectByPattern(pattern: string) {
     const re = globToRegex(pattern);
     const next = new SvelteSet(this.selectedPaths);
-    for (const entry of this.entries) {
+    for (const entry of this.filteredSortedEntries) {
       if (re.test(entry.name)) {
         next.delete(entry.path);
       }
@@ -675,6 +716,7 @@ class PanelsState {
   }
 
   addTab(side: 'left' | 'right'): PanelData {
+    if (comparisonState.active) comparisonState.stopComparison();
     const tab = PanelData.createTab(side);
     if (side === 'left') {
       this.leftTabs = [...this.leftTabs, tab];
@@ -689,19 +731,28 @@ class PanelsState {
   closeTab(side: 'left' | 'right', index: number) {
     const tabs = side === 'left' ? this.leftTabs : this.rightTabs;
     if (tabs.length <= 1) return; // Can't close last tab
+    const activeIndex = side === 'left' ? this.leftActiveTab : this.rightActiveTab;
+    if (comparisonState.active && index === activeIndex) comparisonState.stopComparison();
     const tab = tabs[index];
     tab.stopWatching();
+    if (tab.archiveInfo?.temporaryPath) {
+      cleanupTempPath(tab.archiveInfo.temporaryPath).catch(() => {});
+    }
     const next = tabs.filter((_, i) => i !== index);
     if (side === 'left') {
       this.leftTabs = next;
-      if (this.leftActiveTab >= next.length) this.leftActiveTab = next.length - 1;
+      if (index < this.leftActiveTab) this.leftActiveTab--;
+      else if (this.leftActiveTab >= next.length) this.leftActiveTab = next.length - 1;
     } else {
       this.rightTabs = next;
-      if (this.rightActiveTab >= next.length) this.rightActiveTab = next.length - 1;
+      if (index < this.rightActiveTab) this.rightActiveTab--;
+      else if (this.rightActiveTab >= next.length) this.rightActiveTab = next.length - 1;
     }
   }
 
   switchTab(side: 'left' | 'right', index: number) {
+    const activeIndex = side === 'left' ? this.leftActiveTab : this.rightActiveTab;
+    if (comparisonState.active && index !== activeIndex) comparisonState.stopComparison();
     if (side === 'left') {
       this.leftActiveTab = index;
     } else {
@@ -710,6 +761,7 @@ class PanelsState {
   }
 
   swapPanels() {
+    if (comparisonState.active) comparisonState.stopComparison();
     const tmpTabs = this.leftTabs;
     const tmpActive = this.leftActiveTab;
     this.leftTabs = this.rightTabs;
@@ -717,8 +769,14 @@ class PanelsState {
     this.rightTabs = tmpTabs;
     this.rightActiveTab = tmpActive;
     // Fix watch IDs
-    for (const tab of this.leftTabs) tab.watchId = `watch-left-${tab.tabId}`;
-    for (const tab of this.rightTabs) tab.watchId = `watch-right-${tab.tabId}`;
+    for (const tab of this.leftTabs) {
+      tab.side = 'left';
+      tab.watchId = `watch-left-${tab.tabId}`;
+    }
+    for (const tab of this.rightTabs) {
+      tab.side = 'right';
+      tab.watchId = `watch-right-${tab.tabId}`;
+    }
   }
 }
 

--- a/src/lib/state/transfers.svelte.ts
+++ b/src/lib/state/transfers.svelte.ts
@@ -1,12 +1,12 @@
 import type { ProgressEvent, TransferCheckpoint } from '$lib/types';
-import { cancelFileOperation, pauseFileOperation, copyFiles, moveFiles, deleteFiles, extractArchive } from '$lib/services/tauri';
+import { cancelFileOperation, pauseFileOperation, copyFiles, moveFiles, deleteFiles, extractArchive, createTempDir, cleanupTempPath } from '$lib/services/tauri';
 import { s3Download, s3Upload, s3CopyObjects, s3DeleteObjects, s3UploadEncrypted, type EncryptionConfig } from '$lib/services/s3';
 import { sftpDownload, sftpUpload, sftpDelete } from '$lib/services/sftp';
 import { formatSize } from '$lib/utils/format';
 
 export type TransferStatus = 'queued' | 'running' | 'paused' | 'completed' | 'failed' | 'cancelled';
 type TransferType = 'copy' | 'move' | 'extract' | 'delete';
-type TransferPhase = 'source-to-staging' | 'staging-ready' | 'staging-to-destination' | 'delete-source-ready' | 'delete-source';
+type TransferPhase = 'source-ready' | 'source-to-staging' | 'staging-ready' | 'staging-to-destination' | 'delete-source-ready' | 'delete-source';
 
 export interface Transfer {
   id: string;
@@ -35,6 +35,7 @@ export interface Transfer {
   phase?: TransferPhase;
   pauseRequested?: boolean;
   cancelRequested?: boolean;
+  stagingPath?: string;
   /** Name to focus in the source panel after a move completes. */
   srcFocusName?: string;
   speedBytesPerSec: number;
@@ -233,6 +234,7 @@ class TransfersState {
 
     if (t.status === 'queued' || t.status === 'paused') {
       this.markCancelled(id);
+      await this.releaseStaging(t);
       return;
     }
 
@@ -337,10 +339,12 @@ class TransfersState {
       }
 
       this.throwIfCancelled(t);
+      await this.releaseStaging(t);
       t.checkpoint = null;
       t.phase = undefined;
       this.complete(t.id);
     } catch (err: unknown) {
+      await this.releaseStaging(t);
       const msg = String(err);
       if (msg.includes('cancelled')) {
         this.markCancelled(t.id);
@@ -489,7 +493,13 @@ class TransfersState {
     download: (tempDir: string, checkpoint: TransferCheckpoint | null) => Promise<TransferCheckpoint | null>,
     upload: (sources: string[], checkpoint: TransferCheckpoint | null) => Promise<TransferCheckpoint | null>,
   ): Promise<TransferCheckpoint | null> {
-    const tempDir = `/tmp/furman-xfer-${t.id}`;
+    if (!t.stagingPath) t.stagingPath = await createTempDir('transfer');
+    const tempDir = t.stagingPath;
+    this.throwIfCancelled(t);
+    if (t.pauseRequested && t.phase !== 'source-to-staging') {
+      t.phase = 'source-ready';
+      return this.boundaryCheckpoint(t);
+    }
 
     if (t.phase !== 'staging-ready' && t.phase !== 'staging-to-destination') {
       const checkpoint = t.phase === 'source-to-staging' ? t.checkpoint ?? null : null;
@@ -514,6 +524,7 @@ class TransfersState {
     if (result !== null) return result;
     this.throwIfCancelled(t);
     t.checkpoint = null;
+    await this.releaseStaging(t);
     return null;
   }
 
@@ -554,6 +565,18 @@ class TransfersState {
       files_done: progress?.files_done ?? 0,
       files_total: progress?.files_total ?? 0,
     };
+  }
+
+  private async releaseStaging(t: Transfer) {
+    const path = t.stagingPath;
+    if (!path) return;
+    try {
+      await cleanupTempPath(path);
+    } catch {
+      // Cleanup is best-effort and must not change a completed transfer result.
+    } finally {
+      t.stagingPath = undefined;
+    }
   }
 }
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -507,6 +507,8 @@ export type PanelBackend = 'local' | 's3' | 'sftp' | 'archive';
 export interface ArchiveInfo {
   archivePath: string;
   internalPath: string;
+  /** Temporary remote archive download owned by this panel. */
+  temporaryPath?: string;
   /** When opened from a remote backend, stores info to restore on exit. */
   remoteOrigin?: {
     backend: PanelBackend;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -201,7 +201,7 @@
       }},
       { id: 'select-all', label: 'Select / Deselect all', shortcut: '*', category: 'File', execute: () => {
         const active = panels.active;
-        const allCount = active.entries.filter(e => e.name !== '..').length;
+        const allCount = active.filteredSortedEntries.filter(e => e.name !== '..').length;
         if (active.selectedPaths.size === allCount) active.deselectAll(); else active.selectAll();
       }},
       { id: 'select-by-pattern', label: 'Select by pattern', shortcut: '+', category: 'File', execute: () => {
@@ -676,7 +676,7 @@
         if (!clipboardState.isEmpty) handleClipboardPaste();
         break;
       case 'select-all': {
-        const allCount = active.entries.filter(e => e.name !== '..').length;
+        const allCount = active.filteredSortedEntries.filter(e => e.name !== '..').length;
         if (active.selectedPaths.size === allCount) active.deselectAll();
         else active.selectAll();
         break;
@@ -1108,7 +1108,7 @@
         break;
       case '*': {
         e.preventDefault();
-        const allCount = active.entries.filter(e => e.name !== '..').length;
+        const allCount = active.filteredSortedEntries.filter(e => e.name !== '..').length;
         if (active.selectedPaths.size === allCount) {
           active.deselectAll();
         } else {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -37,6 +37,7 @@
   import { s3BookmarksState } from '$lib/state/s3bookmarks.svelte';
   import { sftpBookmarksState } from '$lib/state/sftpbookmarks.svelte';
   import type { SyncEntry } from '$lib/types';
+  import { closeViewer, closeEditor } from '$lib/actions/viewers';
 
   let _bottomResizing = $state(false);
   let _quakeResizing = $state(false);
@@ -288,17 +289,19 @@
   {/if}
 
   {#if appState.modal === 'viewer'}
-    <Viewer
-      path={appState.viewerPath}
-      mode={appState.viewerMode}
-      onClose={() => appState.closeModal()}
-    />
+    {#key appState.viewerPath}
+      <Viewer
+        path={appState.viewerPath}
+        mode={appState.viewerMode}
+        onClose={closeViewer}
+      />
+    {/key}
   {/if}
 
   {#if appState.modal === 'editor'}
     <Editor
       path={appState.editorPath}
-      onClose={() => appState.closeModal()}
+      onClose={closeEditor}
     />
   {/if}
 


### PR DESCRIPTION
## Summary
- allocate private per-operation temp directories and clean up owned preview, editor, archive, drag, and transfer artifacts
- harden archive extraction path handling and preserve resumable transfer staging safely
- apply side-aware comparison filters consistently across panel views, navigation, cursor, and selection state
- invalidate stale comparison and async viewer state when panels, tabs, or content change

## Validation
- `npm run check`
- `npm run lint`
- `npm run build`
- `cargo test --locked --lib` (17 passed)
- `cargo test --locked --test local_integration` (61 passed)
- `cargo test --locked --test s3_integration -- --test-threads=4` against MinIO (46 passed)
- `cargo test --locked --test sftp_integration -- --test-threads=4` against atmoz/sftp (20 passed, 1 ignored)
- `cargo test --locked --no-run`
- `git diff --check`