### PR TITLE
Fix viewer and editor text selection

### DIFF
--- a/src/lib/components/Viewer.svelte
+++ b/src/lib/components/Viewer.svelte
@@ -426,6 +426,8 @@
     flex: 1 1 0;
     overflow: auto;
     padding: 4px;
+    user-select: text;
+    -webkit-user-select: text;
   }
 
   .viewer-loading,

--- a/src/lib/utils/codemirror.ts
+++ b/src/lib/utils/codemirror.ts
@@ -121,6 +121,9 @@ export const editorTheme = EditorView.theme({
 	'.cm-searchMatch.cm-searchMatch-selected': {
 		backgroundColor: 'rgba(110,168,254,0.5)',
 	},
+	'.cm-selectionMatch': {
+		backgroundColor: 'transparent',
+	},
 	'.cm-panel input': {
 		backgroundColor: 'var(--bg-surface)',
 		color: 'var(--text-primary)',


### PR DESCRIPTION
## Summary
- allow native mouse text selection and copying in text and hex viewer content
- stop CodeMirror from highlighting every occurrence of selected editor text
- preserve normal editor selection and explicit Cmd/Ctrl+F search highlighting

## Validation
- `npm run check`
- `npm run lint`
- `npm run build`
- verified in the Tauri development instance