### PR TITLE
Fix PDF and Markdown previews

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' ipc: http://ipc.localhost; img-src 'self' asset: https://asset.localhost data:; style-src 'self' 'unsafe-inline'",
+      "csp": "default-src 'self' ipc: http://ipc.localhost; img-src 'self' asset: http://asset.localhost https://asset.localhost data:; frame-src 'self' asset: http://asset.localhost https://asset.localhost; style-src 'self' 'unsafe-inline'",
       "assetProtocol": {
         "enable": true,
         "scope": ["**/*"]

--- a/src/lib/components/PreviewPane.svelte
+++ b/src/lib/components/PreviewPane.svelte
@@ -43,6 +43,7 @@
 
   let textContent = $state('');
   let highlightedContent = $state('');
+  let textError = $state('');
   let loading = $state(false);
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
   let loadedPath = $state('');
@@ -92,6 +93,7 @@
       if (loadedPath) {
         textContent = '';
         highlightedContent = '';
+        textError = '';
         loadedPath = '';
       }
       return;
@@ -102,16 +104,18 @@
     loading = true;
     textContent = '';
     highlightedContent = '';
+    textError = '';
     debounceTimer = setTimeout(() => {
       readFileText(currentEntry.path).then((content) => {
         const lines = content.split('\n');
         textContent = lines.slice(0, 200).join('\n');
         if (lines.length > 200) textContent += '\n… (truncated)';
+        if (!textContent) textContent = '(Empty file)';
         const lang = detectLanguage(currentEntry.name);
         highlightedContent = highlightCode(textContent, lang);
         loadedPath = currentEntry.path;
-      }).catch(() => {
-        textContent = '(Unable to read file)';
+      }).catch((err) => {
+        textError = `Unable to read file: ${String(err)}`;
         loadedPath = currentEntry.path;
       }).finally(() => {
         loading = false;
@@ -193,6 +197,8 @@
   {:else if previewType === 'text'}
     {#if loading}
       <div class="preview-loading">Loading...</div>
+    {:else if textError}
+      <div class="preview-error">{textError}</div>
     {:else}
       <pre class="preview-text hljs">{@html highlightedContent}</pre>
     {/if}
@@ -406,6 +412,7 @@
 
   .preview-pdf {
     flex: 1;
+    width: 100%;
     border: none;
     min-height: 0;
     background: white;
@@ -423,6 +430,18 @@
     word-break: break-all;
     min-height: 0;
     tab-size: 4;
+  }
+
+  .preview-error {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    color: var(--text-secondary);
+    font-size: 12px;
+    text-align: center;
+    overflow: auto;
   }
 
   .preview-info-bar {


### PR DESCRIPTION
## Summary
- allow Tauri asset URLs in preview iframes so local PDFs render
- show text preview read errors instead of a blank pane
- show an explicit empty-file state and size PDFs to the pane width

## Security
- keep iframe access limited to the local Tauri asset protocol instead of widening `default-src`

## Verification
- `npm run check`
- `npm run lint`
- `npm run build`
- `cargo +1.94.1 check --locked`