### PR TITLE
Add preview and swap panel toolbar actions

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -169,7 +169,11 @@ pub fn run() {
                 .item(&MenuItemBuilder::with_id("toggle-theme", "Toggle Theme").accelerator("CmdOrCtrl+Shift+L").build(handle)?)
                 .separator()
                 .item(&MenuItemBuilder::with_id("refresh", "Refresh").accelerator("CmdOrCtrl+Shift+R").build(handle)?)
-                .item(&MenuItemBuilder::with_id("swap-panels", "Swap Panels").build(handle)?)
+                .item(
+                    &MenuItemBuilder::with_id("swap-panels", "Swap Panels")
+                        .accelerator("Alt+S")
+                        .build(handle)?,
+                )
                 .item(&MenuItemBuilder::with_id("equal-panels", "Equal Panels").build(handle)?)
                 .item(&MenuItemBuilder::with_id("compare", "Compare Dirs").accelerator("CmdOrCtrl+Shift+D").build(handle)?)
                 .build()?;

--- a/src/lib/components/BreadcrumbBar.svelte
+++ b/src/lib/components/BreadcrumbBar.svelte
@@ -138,7 +138,7 @@
     align-items: center;
     overflow-x: auto;
     white-space: nowrap;
-    padding-right: 52px;
+    padding-right: 76px;
     scrollbar-width: none;
     gap: 2px;
   }

--- a/src/lib/components/BreadcrumbBar.svelte
+++ b/src/lib/components/BreadcrumbBar.svelte
@@ -138,7 +138,7 @@
     align-items: center;
     overflow-x: auto;
     white-space: nowrap;
-    padding-right: 28px;
+    padding-right: 52px;
     scrollbar-width: none;
     gap: 2px;
   }

--- a/src/lib/components/FilePanel.svelte
+++ b/src/lib/components/FilePanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { PanelData } from '$lib/state/panels.svelte';
+  import { panels, type PanelData } from '$lib/state/panels.svelte';
   import type { SortField, ColumnId } from '$lib/types';
   import { SvelteMap, SvelteSet } from 'svelte/reactivity';
   import { appState } from '$lib/state/app.svelte';
@@ -695,6 +695,19 @@
       </button>
     {/if}
     <button
+      class="swap-toggle"
+      onclick={(e) => {
+        e.stopPropagation();
+        panels.swapPanels();
+      }}
+      title="Swap panels (Alt+S)"
+      aria-label="Swap panels"
+    >
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M4 7h14m0 0-3-3m3 3-3 3M20 17H6m0 0 3-3m-3 3 3 3" />
+      </svg>
+    </button>
+    <button
       class="preview-toggle"
       class:active={previewState.visible}
       onclick={() => previewState.toggle()}
@@ -984,9 +997,9 @@
     opacity: 1;
   }
 
-  .preview-toggle {
+  .preview-toggle,
+  .swap-toggle {
     position: absolute;
-    right: 30px;
     top: 50%;
     transform: translateY(-50%);
     display: flex;
@@ -1002,8 +1015,17 @@
     transition: color var(--transition-fast), opacity var(--transition-fast);
   }
 
+  .preview-toggle {
+    right: 30px;
+  }
+
+  .swap-toggle {
+    right: 54px;
+  }
+
   .preview-toggle:hover,
-  .preview-toggle.active {
+  .preview-toggle.active,
+  .swap-toggle:hover {
     opacity: 1;
   }
 
@@ -1011,7 +1033,8 @@
     color: var(--border-active);
   }
 
-  .preview-toggle svg {
+  .preview-toggle svg,
+  .swap-toggle svg {
     width: 16px;
     height: 16px;
     fill: none;
@@ -1023,7 +1046,7 @@
 
   .backend-indicator {
     position: absolute;
-    right: 54px;
+    right: 78px;
     top: 50%;
     transform: translateY(-50%);
     display: flex;

--- a/src/lib/components/FilePanel.svelte
+++ b/src/lib/components/FilePanel.svelte
@@ -14,6 +14,7 @@
   import BreadcrumbBar from './BreadcrumbBar.svelte';
   import ContextMenu from './ContextMenu.svelte';
   import { comparisonState, type ComparisonStatus } from '$lib/state/comparison.svelte';
+  import { previewState } from '$lib/state/preview.svelte';
   import { ALL_COLUMNS } from '$lib/utils/columns';
 
   interface Props {
@@ -693,7 +694,25 @@
         <span class="backend-label">Archive</span>
       </button>
     {/if}
-    <button class="view-toggle" onclick={() => panel.toggleViewMode()} title={panel.viewMode === 'list' ? 'Switch to icon view' : panel.viewMode === 'icon' ? 'Switch to column view' : 'Switch to list view'}>
+    <button
+      class="preview-toggle"
+      class:active={previewState.visible}
+      onclick={() => previewState.toggle()}
+      title={previewState.visible ? 'Hide preview (Alt+P)' : 'Show preview (Alt+P)'}
+      aria-label={previewState.visible ? 'Hide preview' : 'Show preview'}
+      aria-pressed={previewState.visible}
+    >
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M2.25 12s3.5-6 9.75-6 9.75 6 9.75 6-3.5 6-9.75 6S2.25 12 2.25 12Z" />
+        <circle cx="12" cy="12" r="2.75" />
+      </svg>
+    </button>
+    <button
+      class="view-toggle"
+      onclick={() => panel.toggleViewMode()}
+      title={panel.viewMode === 'list' ? 'Switch to icon view' : panel.viewMode === 'icon' ? 'Switch to column view' : 'Switch to list view'}
+      aria-label={panel.viewMode === 'list' ? 'Switch to icon view' : panel.viewMode === 'icon' ? 'Switch to column view' : 'Switch to list view'}
+    >
       {panel.viewMode === 'list' ? '\u229E' : panel.viewMode === 'icon' ? '\u25A5' : '\u2630'}
     </button>
   </div>
@@ -965,9 +984,46 @@
     opacity: 1;
   }
 
-  .backend-indicator {
+  .preview-toggle {
     position: absolute;
     right: 30px;
+    top: 50%;
+    transform: translateY(-50%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: none;
+    color: var(--header-text);
+    cursor: pointer;
+    padding: 2px 4px;
+    line-height: 1;
+    opacity: 0.6;
+    transition: color var(--transition-fast), opacity var(--transition-fast);
+  }
+
+  .preview-toggle:hover,
+  .preview-toggle.active {
+    opacity: 1;
+  }
+
+  .preview-toggle.active {
+    color: var(--border-active);
+  }
+
+  .preview-toggle svg {
+    width: 16px;
+    height: 16px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.7;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .backend-indicator {
+    position: absolute;
+    right: 54px;
     top: 50%;
     transform: translateY(-50%);
     display: flex;

--- a/src/lib/components/ShortcutsDialog.svelte
+++ b/src/lib/components/ShortcutsDialog.svelte
@@ -98,6 +98,7 @@
             { keys: `${platform.mod}Y`, desc: 'Sync directories' },
             { keys: `${platform.mod}${platform.shift}D`, desc: 'Compare directories' },
             { keys: `${platform.alt}P`, desc: 'Toggle preview pane' },
+            { keys: `${platform.alt}S`, desc: 'Swap panels' },
             { keys: `${platform.mod}${platform.shift}L`, desc: 'Toggle dark / light theme' },
           ],
         },

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -233,6 +233,7 @@
 
       // Panel
       { id: 'toggle-layout', label: 'Toggle single / dual pane', shortcut: `${mod}P`, category: 'Panel', execute: () => appState.toggleLayout() },
+      { id: 'swap-panels', label: 'Swap panels', shortcut: `${alt}S`, category: 'Panel', execute: () => panels.swapPanels() },
       { id: 'toggle-sidebar', label: 'Toggle sidebar', shortcut: `${mod}B`, category: 'Panel', execute: () => {
         if (sidebarState.focused) sidebarState.toggle();
         else if (sidebarState.visible) sidebarState.focus();


### PR DESCRIPTION
## Summary
- add preview and swap icons beside each panel's view-mode switcher
- toggle the existing preview pane and show its active state
- expose accessible labels and the `Alt+P` and `Alt+S` shortcuts
- add Swap Panels to the command palette and keyboard-shortcuts dialog
- reserve header space and shift backend indicators to prevent overlap

## Verification
- `npm run check`
- `npm run lint`
- `npm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `git diff --check`