### PR TITLE
Add regex search support

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2261,6 +2261,7 @@ dependencies = [
  "objc2-foundation",
  "portable-pty",
  "rand",
+ "regex",
  "reqwest",
  "rmcp",
  "russh",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -55,6 +55,7 @@ uuid = { version = "1", features = ["v4"] }
 russh = "0.63.0"
 russh-sftp = "2.1"
 glob-match = "0.2"
+regex = "1"
 aws-smithy-http-client = { version = "1", features = ["rustls-aws-lc", "default-client"] }
 
 # MCP server (optional)

--- a/src-tauri/src/commands/s3.rs
+++ b/src-tauri/src/commands/s3.rs
@@ -451,7 +451,6 @@ pub async fn s3_search_objects(
     channel: Channel<SearchEvent>,
 ) -> Result<(), FmError> {
     let service = get_service(&state, &id)?;
-    let matcher = crate::search_matcher::SearchMatcher::new(&query, use_regex)?;
 
     let cancel_flag = Arc::new(AtomicBool::new(false));
     {
@@ -463,7 +462,7 @@ pub async fn s3_search_objects(
     }
 
     service
-        .search_objects(&prefix, &matcher, &cancel_flag, &|evt| {
+        .search_objects(&prefix, &query, use_regex, &cancel_flag, &|evt| {
             let _ = channel.send(evt);
         })
         .await

--- a/src-tauri/src/commands/s3.rs
+++ b/src-tauri/src/commands/s3.rs
@@ -447,9 +447,11 @@ pub async fn s3_search_objects(
     search_id: String,
     prefix: String,
     query: String,
+    use_regex: bool,
     channel: Channel<SearchEvent>,
 ) -> Result<(), FmError> {
     let service = get_service(&state, &id)?;
+    let matcher = crate::search_matcher::SearchMatcher::new(&query, use_regex)?;
 
     let cancel_flag = Arc::new(AtomicBool::new(false));
     {
@@ -461,7 +463,7 @@ pub async fn s3_search_objects(
     }
 
     service
-        .search_objects(&prefix, &query, &cancel_flag, &|evt| {
+        .search_objects(&prefix, &matcher, &cancel_flag, &|evt| {
             let _ = channel.send(evt);
         })
         .await

--- a/src-tauri/src/commands/search.rs
+++ b/src-tauri/src/commands/search.rs
@@ -1,4 +1,5 @@
 use crate::models::{FmError, SearchDone, SearchEvent, SearchResult};
+use crate::search_matcher::SearchMatcher;
 use std::collections::HashMap;
 use std::fs;
 use std::io::{BufRead, BufReader};
@@ -25,9 +26,11 @@ pub fn search_files(
     root: String,
     query: String,
     mode: String, // "name" | "content"
+    use_regex: bool,
     channel: Channel<SearchEvent>,
     state: tauri::State<'_, SearchState>,
 ) -> Result<(), FmError> {
+    let matcher = SearchMatcher::new(&query, use_regex)?;
     let cancel_flag = Arc::new(AtomicBool::new(false));
     {
         let mut map = state.0.lock().map_err(|e| FmError::Other(e.to_string()))?;
@@ -37,7 +40,7 @@ pub fn search_files(
     // Spawn a thread for the blocking directory walk.
     // The channel streams results back to the frontend as they're found.
     std::thread::spawn(move || {
-        do_search(&root, &query, &mode, &channel, &cancel_flag);
+        do_search(&root, &mode, &matcher, &channel, &cancel_flag);
     });
 
     Ok(())
@@ -56,12 +59,11 @@ pub fn cancel_search(id: String, state: tauri::State<'_, SearchState>) -> Result
 
 fn do_search(
     root: &str,
-    query: &str,
     mode: &str,
+    matcher: &SearchMatcher,
     channel: &Channel<SearchEvent>,
     cancel_flag: &Arc<AtomicBool>,
 ) {
-    let query_lower = query.to_lowercase();
     let is_content = mode == "content";
     let root_path = PathBuf::from(root);
 
@@ -119,7 +121,7 @@ fn do_search(
                 if file_size > MAX_CONTENT_FILE_SIZE {
                     continue;
                 }
-                if let Some((line_num, snippet)) = search_file_content(&path, &query_lower) {
+                if let Some((line_num, snippet)) = search_file_content(&path, matcher) {
                     total_found += 1;
                     if streamed < MAX_STREAMED_RESULTS {
                         let _ = channel.send(SearchEvent::Result(SearchResult {
@@ -134,8 +136,8 @@ fn do_search(
                     }
                 }
             } else {
-                // Name search: case-insensitive substring match.
-                if file_name.to_lowercase().contains(&query_lower) {
+                // Name search: literal substring or regular expression.
+                if matcher.is_match(&file_name) {
                     total_found += 1;
                     if streamed < MAX_STREAMED_RESULTS {
                         let _ = channel.send(SearchEvent::Result(SearchResult {
@@ -161,9 +163,9 @@ fn do_search(
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-/// Search a file's content line-by-line for a case-insensitive substring match.
+/// Search a file's content line-by-line and return the first match.
 /// Returns the first match as (line_number, trimmed_snippet).
-fn search_file_content(path: &PathBuf, query_lower: &str) -> Option<(u32, String)> {
+fn search_file_content(path: &PathBuf, matcher: &SearchMatcher) -> Option<(u32, String)> {
     let file = fs::File::open(path).ok()?;
     let reader = BufReader::new(file);
 
@@ -172,7 +174,7 @@ fn search_file_content(path: &PathBuf, query_lower: &str) -> Option<(u32, String
             Ok(l) => l,
             Err(_) => return None, // binary / non-UTF-8 — skip entire file
         };
-        if line.to_lowercase().contains(query_lower) {
+        if matcher.is_match(&line) {
             let trimmed = line.trim().to_string();
             // Cap snippet length for the frontend.
             let snippet = if trimmed.len() > 200 {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ pub mod model_inspector;
 pub mod models;
 pub mod oidc;
 pub mod s3;
+mod search_matcher;
 pub mod sftp;
 
 use commands::disk_usage::DiskUsageState;

--- a/src-tauri/src/s3/service.rs
+++ b/src-tauri/src/s3/service.rs
@@ -1393,11 +1393,10 @@ impl S3Service {
     pub async fn search_objects(
         &self,
         prefix: &str,
-        query: &str,
+        matcher: &crate::search_matcher::SearchMatcher,
         cancel: &AtomicBool,
         on_result: &(dyn Fn(SearchEvent) + Send + Sync),
     ) -> Result<(), FmError> {
-        let query_lower = query.to_lowercase();
         let mut continuation_token: Option<String> = None;
         let mut total_found: u32 = 0;
         let mut streamed: u32 = 0;
@@ -1443,7 +1442,7 @@ impl S3Service {
                     continue;
                 }
 
-                if filename.to_lowercase().contains(&query_lower) {
+                if matcher.is_match(filename) {
                     total_found += 1;
                     if streamed < MAX_STREAMED {
                         let size = obj.size().unwrap_or(0) as u64;

--- a/src-tauri/src/s3/service.rs
+++ b/src-tauri/src/s3/service.rs
@@ -1393,10 +1393,12 @@ impl S3Service {
     pub async fn search_objects(
         &self,
         prefix: &str,
-        matcher: &crate::search_matcher::SearchMatcher,
+        query: &str,
+        use_regex: bool,
         cancel: &AtomicBool,
         on_result: &(dyn Fn(SearchEvent) + Send + Sync),
     ) -> Result<(), FmError> {
+        let matcher = crate::search_matcher::SearchMatcher::new(query, use_regex)?;
         let mut continuation_token: Option<String> = None;
         let mut total_found: u32 = 0;
         let mut streamed: u32 = 0;

--- a/src-tauri/src/search_matcher.rs
+++ b/src-tauri/src/search_matcher.rs
@@ -1,0 +1,56 @@
+use crate::models::FmError;
+use regex::{Regex, RegexBuilder};
+
+pub enum SearchMatcher {
+    Literal(String),
+    Regex(Regex),
+}
+
+impl SearchMatcher {
+    pub fn new(query: &str, use_regex: bool) -> Result<Self, FmError> {
+        if use_regex {
+            let regex = RegexBuilder::new(query)
+                .case_insensitive(true)
+                .build()
+                .map_err(|error| FmError::Other(format!("Invalid regular expression: {error}")))?;
+            Ok(Self::Regex(regex))
+        } else {
+            Ok(Self::Literal(query.to_lowercase()))
+        }
+    }
+
+    pub fn is_match(&self, text: &str) -> bool {
+        match self {
+            Self::Literal(query) => text.to_lowercase().contains(query),
+            Self::Regex(regex) => regex.is_match(text),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SearchMatcher;
+
+    #[test]
+    fn literal_search_is_case_insensitive() {
+        let matcher = SearchMatcher::new("report", false).unwrap();
+
+        assert!(matcher.is_match("Annual Report.pdf"));
+        assert!(!matcher.is_match("summary.pdf"));
+    }
+
+    #[test]
+    fn regex_search_is_case_insensitive_and_supports_anchors() {
+        let matcher = SearchMatcher::new(r"^img_\d+\.webp$", true).unwrap();
+
+        assert!(matcher.is_match("IMG_42.WEBP"));
+        assert!(!matcher.is_match("old_IMG_42.webp"));
+    }
+
+    #[test]
+    fn invalid_regex_returns_an_error() {
+        let error = SearchMatcher::new("[", true).err().unwrap();
+
+        assert!(error.to_string().starts_with("Invalid regular expression:"));
+    }
+}

--- a/src-tauri/tests/s3_integration.rs
+++ b/src-tauri/tests/s3_integration.rs
@@ -960,7 +960,7 @@ async fn test_search_objects() {
     let results = std::sync::Mutex::new(Vec::new());
 
     ctx.service
-        .search_objects("search/", "hello", &cancel, &|evt| {
+        .search_objects("search/", "hello", false, &cancel, &|evt| {
             results.lock().unwrap().push(evt);
         })
         .await

--- a/src/lib/components/SearchDialog.svelte
+++ b/src/lib/components/SearchDialog.svelte
@@ -16,11 +16,13 @@
 
   let query = $state('');
   let mode = $state<SearchMode>('name');
+  let useRegex = $state(false);
   let results = $state<SearchResult[]>([]);
   let cursorIndex = $state(0);
   let searching = $state(false);
   let totalFound = $state(0);
   let searchComplete = $state(false);
+  let searchError = $state('');
   let currentSearchId = $state('');
   let inputEl: HTMLInputElement | undefined = $state(undefined);
   let resultsEl: HTMLDivElement | undefined = $state(undefined);
@@ -65,10 +67,11 @@
       await cancelSearch(currentSearchId).catch(() => {});
     }
 
-    if (query.length < 2) {
+    if (query.length < (useRegex ? 1 : 2)) {
       results = [];
       searching = false;
       searchComplete = false;
+      searchError = '';
       totalFound = 0;
       currentSearchId = '';
       return;
@@ -80,6 +83,7 @@
     cursorIndex = 0;
     totalFound = 0;
     searchComplete = false;
+    searchError = '';
     searching = true;
 
     const handleEvent = (event: SearchEvent) => {
@@ -101,12 +105,13 @@
           // Extract prefix from s3://bucket/prefix path
           const m = root.match(/^s3:\/\/[^/]+\/(.*)$/);
           const prefix = m ? m[1] : '';
-          return s3SearchObjects(s3ConnectionId, id, prefix, query, handleEvent);
+          return s3SearchObjects(s3ConnectionId, id, prefix, query, useRegex, handleEvent);
         })()
-      : searchFiles(id, root, query, mode, handleEvent);
+      : searchFiles(id, root, query, mode, useRegex, handleEvent);
 
-    searchPromise.catch(() => {
+    searchPromise.catch((error: unknown) => {
       if (id === currentSearchId) {
+        searchError = String(error);
         searching = false;
         searchComplete = true;
       }
@@ -123,6 +128,11 @@
   function handleModeChange(newMode: SearchMode) {
     mode = newMode;
     // Re-trigger search with the new mode.
+    clearTimeout(debounceTimer);
+    doSearch();
+  }
+
+  function handleRegexChange() {
     clearTimeout(debounceTimer);
     doSearch();
   }
@@ -216,23 +226,34 @@
           bind:value={query}
           bind:this={inputEl}
           oninput={handleInput}
-          placeholder={mode === 'name' ? 'File or directory name...' : 'Search file contents...'}
+          placeholder={useRegex ? 'Regular expression...' : mode === 'name' ? 'File or directory name...' : 'Search file contents...'}
+          aria-invalid={searchError ? 'true' : undefined}
+          aria-describedby={searchError ? 'search-error' : undefined}
         />
       </div>
 
-      {#if backend !== 's3'}
-        <div class="mode-toggle">
-          <button
-            class="mode-btn"
-            class:active={mode === 'name'}
-            onclick={() => handleModeChange('name')}
-          >Name</button>
-          <button
-            class="mode-btn"
-            class:active={mode === 'content'}
-            onclick={() => handleModeChange('content')}
-          >Content</button>
-        </div>
+      <div class="search-options">
+        {#if backend !== 's3'}
+          <div class="mode-toggle">
+            <button
+              class="mode-btn"
+              class:active={mode === 'name'}
+              onclick={() => handleModeChange('name')}
+            >Name</button>
+            <button
+              class="mode-btn"
+              class:active={mode === 'content'}
+              onclick={() => handleModeChange('content')}
+            >Content</button>
+          </div>
+        {/if}
+        <label class="regex-toggle" title="Case-insensitive Rust regular expression">
+          <input type="checkbox" bind:checked={useRegex} onchange={handleRegexChange} />
+          Regex
+        </label>
+      </div>
+      {#if searchError}
+        <div id="search-error" class="search-error">{searchError}</div>
       {/if}
 
       <div class="results-list" bind:this={resultsEl}>
@@ -355,7 +376,32 @@
     border: 1px solid var(--border-subtle);
     border-radius: var(--radius-sm);
     overflow: hidden;
-    align-self: flex-start;
+  }
+
+  .search-options {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .regex-toggle {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    color: var(--text-secondary);
+    font-size: 12px;
+    cursor: pointer;
+  }
+
+  .regex-toggle input {
+    margin: 0;
+  }
+
+  .search-error {
+    color: var(--error-color);
+    font-size: 11px;
+    line-height: 1.4;
+    white-space: pre-wrap;
   }
 
   .mode-btn {

--- a/src/lib/services/s3.ts
+++ b/src/lib/services/s3.ts
@@ -225,11 +225,12 @@ export async function s3SearchObjects(
   searchId: string,
   prefix: string,
   query: string,
+  useRegex: boolean,
   onEvent: (e: SearchEvent) => void,
 ): Promise<void> {
   const channel = new Channel<SearchEvent>();
   channel.onmessage = onEvent;
-  await invoke('s3_search_objects', { id, searchId, prefix, query, channel });
+  await invoke('s3_search_objects', { id, searchId, prefix, query, useRegex, channel });
 }
 
 // ── Bucket Management ───────────────────────────────────────────────────────

--- a/src/lib/services/tauri.ts
+++ b/src/lib/services/tauri.ts
@@ -201,11 +201,12 @@ export async function searchFiles(
   root: string,
   query: string,
   mode: SearchMode,
+  useRegex: boolean,
   onEvent: (e: SearchEvent) => void
 ): Promise<void> {
   const channel = new Channel<SearchEvent>();
   channel.onmessage = onEvent;
-  await invoke('search_files', { id, root, query, mode, channel });
+  await invoke('search_files', { id, root, query, mode, useRegex, channel });
 }
 
 export async function cancelSearch(id: string): Promise<void> {


### PR DESCRIPTION
## Summary
- add a Regex toggle to the search dialog
- support case-insensitive Rust regular expressions for local name and content searches
- support the same regex matching for S3 object names
- preserve existing case-insensitive literal substring search
- display invalid-pattern errors in the search dialog
- add focused tests for literal, regex, and invalid-pattern matching

## Verification
- `npm run check`
- `npm run lint`
- `npm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib`
- `git diff --check`