### PR TITLE
Add navigation toolbar and favorite actions

### DIFF
--- a/src/lib/components/BreadcrumbBar.svelte
+++ b/src/lib/components/BreadcrumbBar.svelte
@@ -138,7 +138,7 @@
     align-items: center;
     overflow-x: auto;
     white-space: nowrap;
-    padding-right: 76px;
+    padding-right: 124px;
     scrollbar-width: none;
     gap: 2px;
   }

--- a/src/lib/components/ContextMenu.svelte
+++ b/src/lib/components/ContextMenu.svelte
@@ -12,10 +12,11 @@
     isFile?: boolean;
     isArchive?: boolean;
     isLocalDir?: boolean;
+    isFavorite?: boolean;
     onEmpty?: boolean;
   }
 
-  let { x, y, onClose, onAction, isS3 = false, isFile = false, isArchive: _isArchive = false, isLocalDir = false, onEmpty = false }: Props = $props();
+  let { x, y, onClose, onAction, isS3 = false, isFile = false, isArchive: _isArchive = false, isLocalDir = false, isFavorite = false, onEmpty = false }: Props = $props();
 
   let menuEl: HTMLDivElement | undefined = $state(undefined);
   let adjustX = $state(0);
@@ -135,6 +136,9 @@
       </button>
 
       {#if isLocalDir}
+        <button class="menu-row" role="menuitem" disabled={isFavorite} onclick={() => act('add-favorite')}>
+          {isFavorite ? 'In Favorites' : 'Add to Favorites'}
+        </button>
         <button class="menu-row" role="menuitem" onclick={() => act('disk-usage')}>
           Disk Usage
           <span class="menu-shortcut">{platform.mod}{platform.shift}U</span>

--- a/src/lib/components/FilePanel.svelte
+++ b/src/lib/components/FilePanel.svelte
@@ -15,6 +15,7 @@
   import ContextMenu from './ContextMenu.svelte';
   import { comparisonState, type ComparisonStatus } from '$lib/state/comparison.svelte';
   import { previewState } from '$lib/state/preview.svelte';
+  import { sidebarState } from '$lib/state/sidebar.svelte';
   import { ALL_COLUMNS } from '$lib/utils/columns';
 
   interface Props {
@@ -321,6 +322,16 @@
       if (entry && entry.is_dir && panel.backend === 'local') {
         const targetPath = entry.name === '..' ? panel.path : entry.path;
         window.dispatchEvent(new CustomEvent('disk-usage-request', { detail: targetPath }));
+      }
+      return;
+    }
+    if (key === 'add-favorite') {
+      const entry = panel.currentEntry;
+      if (entry?.is_dir) {
+        const path = entry.path.replace(/\/+$/, '') || '/';
+        const name = path.split('/').pop() || path;
+        sidebarState.addFavorite(name, path);
+        statusState.setMessage(`Added ${name} to favorites`);
       }
       return;
     }
@@ -695,6 +706,40 @@
       </button>
     {/if}
     <button
+      class="sidebar-toggle"
+      class:active={sidebarState.visible}
+      onclick={(e) => {
+        e.stopPropagation();
+        sidebarState.toggle();
+      }}
+      title={sidebarState.visible ? `Hide sidebar (${platform.mod}B)` : `Show sidebar (${platform.mod}B)`}
+      aria-label={sidebarState.visible ? 'Hide sidebar' : 'Show sidebar'}
+      aria-pressed={sidebarState.visible}
+    >
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <rect x="3" y="4" width="18" height="16" rx="2" />
+        <path d="M8 4v16" />
+      </svg>
+    </button>
+    <button
+      class="layout-toggle"
+      class:active={appState.layoutMode === 'dual'}
+      onclick={(e) => {
+        e.stopPropagation();
+        appState.toggleLayout();
+      }}
+      title={appState.layoutMode === 'dual' ? `Switch to single pane (${platform.mod}P)` : `Switch to dual pane (${platform.mod}P)`}
+      aria-label={appState.layoutMode === 'dual' ? 'Switch to single pane' : 'Switch to dual pane'}
+      aria-pressed={appState.layoutMode === 'dual'}
+    >
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <rect x="3" y="4" width="18" height="16" rx="2" />
+        {#if appState.layoutMode === 'dual'}
+          <path d="M12 4v16" />
+        {/if}
+      </svg>
+    </button>
+    <button
       class="swap-toggle"
       onclick={(e) => {
         e.stopPropagation();
@@ -912,6 +957,7 @@
       isFile={!!(panel.currentEntry && !panel.currentEntry.is_dir && panel.currentEntry.name !== '..')}
       isArchive={panel.backend === 'archive'}
       isLocalDir={panel.backend === 'local' && !!(panel.currentEntry && panel.currentEntry.is_dir)}
+      isFavorite={sidebarState.hasFavorite(panel.currentEntry?.path ?? '')}
       onEmpty={contextMenuOnEmpty}
     />
   {/if}
@@ -998,7 +1044,9 @@
   }
 
   .preview-toggle,
-  .swap-toggle {
+  .swap-toggle,
+  .layout-toggle,
+  .sidebar-toggle {
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
@@ -1023,18 +1071,34 @@
     right: 54px;
   }
 
+  .layout-toggle {
+    right: 78px;
+  }
+
+  .sidebar-toggle {
+    right: 102px;
+  }
+
   .preview-toggle:hover,
   .preview-toggle.active,
-  .swap-toggle:hover {
+  .swap-toggle:hover,
+  .layout-toggle:hover,
+  .layout-toggle.active,
+  .sidebar-toggle:hover,
+  .sidebar-toggle.active {
     opacity: 1;
   }
 
-  .preview-toggle.active {
+  .preview-toggle.active,
+  .layout-toggle.active,
+  .sidebar-toggle.active {
     color: var(--border-active);
   }
 
   .preview-toggle svg,
-  .swap-toggle svg {
+  .swap-toggle svg,
+  .layout-toggle svg,
+  .sidebar-toggle svg {
     width: 16px;
     height: 16px;
     fill: none;
@@ -1046,7 +1110,7 @@
 
   .backend-indicator {
     position: absolute;
-    right: 78px;
+    right: 126px;
     top: 50%;
     transform: translateY(-50%);
     display: flex;

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -133,6 +133,13 @@
     sidebarState.addFavorite(name, path);
   }
 
+  function renameFavorite(path: string, currentName: string) {
+    appState.showInput('Favorite name:', currentName, (name) => {
+      appState.closeModal();
+      sidebarState.renameFavorite(path, name);
+    });
+  }
+
   async function navigateWorkspace(ws: { name: string; leftPath: string; rightPath: string; activePanel: 'left' | 'right'; leftTabs?: string[]; rightTabs?: string[]; leftActiveTab?: number; rightActiveTab?: number }) {
     sidebarState.blur();
     panels.activePanel = ws.activePanel;
@@ -316,6 +323,12 @@
         <!-- svelte-ignore a11y_click_events_have_key_events -->
         <div class="sidebar-item" class:focused={isFocused(i)} onclick={() => navigateFavorite(fav.path)} role="button" tabindex="-1">
           <span class="item-name">{fav.name}</span>
+          <button
+            class="rename-btn"
+            onclick={(e) => { e.stopPropagation(); renameFavorite(fav.path, fav.name); }}
+            title="Rename favorite"
+            aria-label={`Rename ${fav.name}`}
+          >&#x270E;</button>
           <button
             class="remove-btn"
             onclick={(e) => { e.stopPropagation(); sidebarState.removeFavorite(fav.path); }}
@@ -523,18 +536,32 @@
     white-space: nowrap;
   }
 
+  .rename-btn,
   .remove-btn {
     display: none;
-    font-size: 16px;
     line-height: 1;
     color: var(--text-secondary);
     padding: 0 2px;
+    background: transparent;
+    border: none;
+    cursor: pointer;
   }
 
+  .rename-btn {
+    font-size: 13px;
+  }
+
+  .remove-btn {
+    font-size: 16px;
+  }
+
+  .rename-btn:hover,
   .remove-btn:hover {
     color: var(--text-primary);
   }
 
+  .sidebar-item:hover .rename-btn,
+  .sidebar-item.focused .rename-btn,
   .sidebar-item:hover .remove-btn,
   .sidebar-item.focused .remove-btn {
     display: block;

--- a/src/lib/state/sidebar.svelte.ts
+++ b/src/lib/state/sidebar.svelte.ts
@@ -64,13 +64,30 @@ class SidebarState {
   }
 
   addFavorite(name: string, path: string) {
-    if (this.favorites.some((f) => f.path === path)) return;
+    if (this.hasFavorite(path)) return;
     this.favorites = [...this.favorites, { name, path }];
     this.persistFavorites();
   }
 
+  hasFavorite(path: string): boolean {
+    const normalized = path.replace(/\/+$/, '') || '/';
+    return this.favorites.some((favorite) => (favorite.path.replace(/\/+$/, '') || '/') === normalized);
+  }
+
   removeFavorite(path: string) {
     this.favorites = this.favorites.filter((f) => f.path !== path);
+    this.persistFavorites();
+  }
+
+  renameFavorite(path: string, name: string) {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    const normalized = path.replace(/\/+$/, '') || '/';
+    this.favorites = this.favorites.map((favorite) =>
+      (favorite.path.replace(/\/+$/, '') || '/') === normalized
+        ? { ...favorite, name: trimmed }
+        : favorite
+    );
     this.persistFavorites();
   }
 


### PR DESCRIPTION
## Summary
- add sidebar visibility and single/dual-pane controls to panel headers
- allow local folders to be added to Favorites from their context menu
- allow persisted favorite display names to be renamed from the sidebar

## Validation
- npm run check
- npm run lint
- npm run build
- git diff --check