### PR TITLE
Bump version to 0.3.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "furman-filemanager",
-	"version": "0.3.15",
+	"version": "0.3.16",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "furman-filemanager",
-			"version": "0.3.15",
+			"version": "0.3.16",
 			"dependencies": {
 				"@codemirror/lang-cpp": "^6.0.3",
 				"@codemirror/lang-css": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "furman-filemanager",
 	"private": true,
-	"version": "0.3.15",
+	"version": "0.3.16",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2230,7 +2230,7 @@ dependencies = [
 
 [[package]]
 name = "furman"
-version = "0.3.15"
+version = "0.3.16"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "furman"
-version = "0.3.15"
+version = "0.3.16"
 description = "Furman File Manager"
 authors = ["Bartosz Fenski"]
 license = "GPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Furman",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "identifier": "com.furman.filemanager",
   "build": {
     "frontendDist": "../build",


### PR DESCRIPTION
## Summary
- bump npm package metadata to 0.3.16
- bump Rust crate and Tauri application metadata to 0.3.16

## Validation
- npm run check
- npm run lint
- npm run build
- cargo check --locked --manifest-path src-tauri/Cargo.toml
- git diff --check